### PR TITLE
feat: Add webhook security improvements and validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "recharts": "^3.1.0",
+        "replicate": "^1.0.1",
         "tailwind-merge": "^3.3.1",
         "uuid": "^11.1.0"
       },
@@ -1930,6 +1931,19 @@
         "darwin"
       ]
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2303,6 +2317,27 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -2367,6 +2402,31 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/busboy": {
@@ -3569,10 +3629,30 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.8.x"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4099,6 +4179,27 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -5485,6 +5586,16 @@
         }
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -5651,6 +5762,23 @@
         "pify": "^2.3.0"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -5742,6 +5870,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/replicate": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/replicate/-/replicate-1.0.1.tgz",
+      "integrity": "sha512-EY+rK1YR5bKHcM9pd6WyaIbv6m2aRIvHfHDh51j/LahlHTLKemTYXF6ptif2sLa+YospupAsIoxw8Ndt5nI3vg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "git": ">=2.11.0",
+        "node": ">=18.0.0",
+        "npm": ">=7.19.0",
+        "yarn": ">=1.7.0"
+      },
+      "optionalDependencies": {
+        "readable-stream": ">=4.0.0"
       }
     },
     "node_modules/reselect": {
@@ -5838,6 +5981,27 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -6123,6 +6287,16 @@
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "recharts": "^3.1.0",
+    "replicate": "^1.0.1",
     "tailwind-merge": "^3.3.1",
     "uuid": "^11.1.0"
   },

--- a/src/app/api/analyze-url/route.ts
+++ b/src/app/api/analyze-url/route.ts
@@ -24,8 +24,12 @@ async function startReplicatePrediction(fileUrl: string) {
 
   const webhookUrl = `${baseUrl}/api/webhook`;
   
-  // Validate webhook URL
-  if (!webhookUrl.startsWith('https://') && !webhookUrl.startsWith('http://localhost')) {
+  // 웹훅 URL 검증
+  if (process.env.NODE_ENV === 'production') {
+    if (!webhookUrl.startsWith('https://')) {
+      throw new Error(`Invalid webhook URL in production: ${webhookUrl}. Must be HTTPS.`);
+    }
+  } else if (!webhookUrl.startsWith('http://localhost')) {
     throw new Error(`Invalid webhook URL: ${webhookUrl}. Must be HTTPS or localhost.`);
   }
   

--- a/src/app/api/webhook/route.ts
+++ b/src/app/api/webhook/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { supabase } from '@/lib/supabaseClient';
 import type { TranscriptItem } from '@/context/AnalysisResultContext';
+import { validateWebhook } from 'replicate';
 
 // Replicate가 웹훅으로 보내는 데이터 타입
 interface ReplicateWebhookPayload {
@@ -17,43 +18,63 @@ interface ReplicateWebhookPayload {
 }
 
 export async function POST(request: Request) {
-  const payload = (await request.json()) as ReplicateWebhookPayload;
-  console.log("Received webhook from Replicate:", payload);
-
-  // 1. 분석이 성공적으로 완료된 경우에만 DB에 저장
-  if (payload.status === "succeeded" && payload.output) {
-    console.log("Analysis succeeded. Saving to Supabase...");
-
-    const { metrics, transcript } = payload.output;
-
-    try {
-      // 2. Supabase 'analysis_results' 테이블에 결과 삽입
-      const { error: dbError } = await supabase
-        .from('analysis_results')
-        .insert({ 
-          session_id: metrics.session_id, 
-          metrics: metrics,
-          transcript: transcript,
-        });
-
-      if (dbError) {
-        console.error("Database insert error:", dbError);
-        // DB 저장 실패 시 에러 응답
-        return NextResponse.json({ message: `Database error: ${dbError.message}` }, { status: 500 });
-      }
-
-      console.log(`Successfully saved analysis for session_id: ${metrics.session_id}`);
-
-    } catch (error: unknown) {
-      const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred during DB operation.';
-      console.error(errorMessage);
-      return NextResponse.json({ message: errorMessage }, { status: 500 });
+  try {
+    // 웹훅 서명 검증
+    const secret = process.env.REPLICATE_WEBHOOK_SIGNING_SECRET;
+    if (!secret) {
+      console.error("REPLICATE_WEBHOOK_SIGNING_SECRET 환경 변수가 설정되지 않았습니다.");
+      return NextResponse.json({ message: "Invalid webhook signature" }, { status: 401 });
     }
-  } else if (payload.status === 'failed' || payload.status === 'canceled') {
-    console.error(`Analysis ${payload.id} failed or was canceled. Error: ${payload.error}`);
-    // TODO: 실패 상태도 DB에 기록할 수 있습니다.
-  }
 
-  // 3. Replicate에 성공적으로 웹훅을 수신했음을 알림
-  return NextResponse.json({ message: 'Webhook received successfully' }, { status: 200 });
+    const isValid = await validateWebhook(request, secret);
+    if (!isValid) {
+      console.error("Invalid webhook signature received");
+      return NextResponse.json({ message: "Invalid webhook signature" }, { status: 401 });
+    }
+
+    const payload = (await request.json()) as ReplicateWebhookPayload;
+    console.log("Received valid webhook from Replicate:", payload);
+
+    // 1. 분석이 성공적으로 완료된 경우에만 DB에 저장
+    if (payload.status === "succeeded" && payload.output) {
+      console.log("Analysis succeeded. Saving to Supabase...");
+
+      const { metrics, transcript } = payload.output;
+
+      try {
+        // 2. Supabase 'analysis_results' 테이블에 결과 삽입
+        const { error: dbError } = await supabase
+          .from('analysis_results')
+          .insert({ 
+            session_id: metrics.session_id, 
+            metrics: metrics,
+            transcript: transcript,
+          });
+
+        if (dbError) {
+          console.error("Database insert error:", dbError);
+          // DB 저장 실패 시 에러 응답
+          return NextResponse.json({ message: `Database error: ${dbError.message}` }, { status: 500 });
+        }
+
+        console.log(`Successfully saved analysis for session_id: ${metrics.session_id}`);
+
+      } catch (error: unknown) {
+        const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred during DB operation.';
+        console.error(errorMessage);
+        return NextResponse.json({ message: errorMessage }, { status: 500 });
+      }
+    } else if (payload.status === 'failed' || payload.status === 'canceled') {
+      console.error(`Analysis ${payload.id} failed or was canceled. Error: ${payload.error}`);
+      // TODO: 실패 상태도 DB에 기록할 수 있습니다.
+    }
+
+    // 3. Replicate에 성공적으로 웹훅을 수신했음을 알림
+    return NextResponse.json({ message: 'Webhook received successfully' }, { status: 200 });
+
+  } catch (error: unknown) {
+    const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred';
+    console.error("Webhook processing error:", errorMessage);
+    return NextResponse.json({ message: errorMessage }, { status: 500 });
+  }
 }


### PR DESCRIPTION
## 개요
Replicate 웹훅 보안 및 유효성 검사를 개선했습니다.

## 변경 사항
- Replicate 웹훅 서명 검증 추가 (보안 강화)
- 프로덕션 환경에서 HTTPS 강제 적용
- 웹훅 처리 오류 로깅 개선
- 웹훅 URL 유효성 검사 강화

## 테스트 방법
1. Replicate 대시보드에서 웹훅 서명 시크릿 생성
2. `.env` 파일에 `REPLICATE_WEBHOOK_SIGNING_SECRET` 추가
3. 웹훅 테스트를 위해 파일 업로드 시도
4. 서버 로그에서 웹훅 처리 로그 확인

## 참고 사항
- 반드시 Replicate 대시보드에서 웹훅 서명 시크릿을 설정해야 합니다.
- 프로덕션 환경에서는 HTTPS가 필수입니다.