### PR TITLE
feat: 상담사 대시보드 레이아웃 및 UI/UX 전면 개선

### DIFF
--- a/src/app/consultant/page.tsx
+++ b/src/app/consultant/page.tsx
@@ -1,197 +1,138 @@
 "use client";
 
 import DashboardLayout from "@/components/DashboardLayout";
-import { BarChart3, MessageCircle, Clock, TrendingUp, Award, AlertCircle } from "lucide-react";
+import { RadarChart } from "@/components/charts/RadarChart";
 
 export default function ConsultantDashboardPage() {
-  // 상담사 개인 데이터 (예시)
-  const consultantData = {
-    name: "김민수",
-    id: "C001",
-    team: "고객상담 1팀",
-    position: "선임 상담사",
-    profileImage: null
+  // 전일 상담 분석
+  const yesterdayAnalysis = {
+    strengths: "고객의 말을 경청하고, 친절하게 안내하였습니다.",
+    improvements: "전문 용어 사용 시 추가 설명이 필요합니다.",
+    coaching: "고객의 감정에 공감하는 멘트를 한 번 더 추가해보세요.",
   };
 
-  const todayStats = {
-    callsCompleted: 23,
-    avgCallDuration: "5분 32초",
-    satisfactionScore: 4.8,
-    resolvedIssues: 21
-  };
+  // 전일 평균 점수
+  const yesterdayAvgScore = 75;
 
-  const weeklyPerformance = {
-    totalCalls: 142,
-    avgSatisfaction: 4.7,
-    improvementRate: "+12%",
-    rankInTeam: 2
-  };
+  // 5대 지표 점수 및 등급 (예시)
+  const indicators = [
+    { label: "정중함 및 언어 품질", score: 60, grade: "G" },
+    { label: "대화 흐름 및 응대 태도", score: 80, grade: "B" },
+    { label: "공감적 소통", score: 70, grade: "C" },
+    { label: "감정 안정성", score: 65, grade: "C" },
+    { label: "문제 해결 역량", score: 85, grade: "A" },
+  ];
+
+  // RadarChart용 데이터 변환 (subject, A 구조)
+  const radarData = indicators.map((item) => ({
+    subject: item.label,
+    A: item.score,
+    fullMark: 100,
+  }));
+
+  // 점수 낮은 2개 지표 추출 (score 오름차순)
+  const lowIndicators = [...indicators]
+    .sort((a, b) => a.score - b.score)
+    .slice(0, 2);
+
+  // 상담사 정보 (이니셜, 이름)
+  const userName = "마교준석";
+  const userInitial = userName[0];
 
   return (
     <DashboardLayout>
-      <div className="h-full bg-gradient-to-br from-pink-50 via-purple-50 to-indigo-50 p-2 sm:p-4 lg:p-6">
-        <div className="h-full space-y-4 sm:space-y-6">
-          {/* 헤더 */}
-          <div className="bg-gradient-to-r from-pink-500 to-purple-600 rounded-xl p-4 sm:p-6 text-white shadow-xl">
-            <div className="flex items-center justify-between">
-              <div className="flex-1">
-                <h1 className="text-lg sm:text-xl lg:text-2xl xl:text-3xl font-bold mb-2">
-                  안녕하세요, {consultantData.name}님! 👋
-                </h1>
-                <p className="text-sm sm:text-base text-white/90">
-                  {consultantData.team} • {consultantData.position}
-                </p>
+      <div className="w-full h-full bg-gradient-to-br from-pink-50 via-purple-50 to-indigo-50 p-6">
+        {/* 수정: h-96 -> h-full */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 h-full">
+          {/* 왼쪽 카드 세로 배치 */}
+          {/* 수정: h-128, justify-center 제거 */}
+          <div className="flex flex-col gap-4">
+            {/* 인사말 카드 */}
+            <div className="bg-gradient-to-r from-pink-400 to-purple-400 rounded-2xl p-6 shadow-lg flex items-center gap-4 animate-pulse-glow">
+              <div className="h-12 w-12 rounded-full bg-white/30 flex items-center justify-center text-2xl font-bold text-white shadow">
+                {userInitial}
               </div>
-              <div className="hidden sm:flex items-center space-x-4">
-                <div className="bg-white/20 backdrop-blur-sm rounded-lg p-2 sm:p-3">
-                  <div className="text-xs sm:text-sm text-white/80">현재 시각</div>
-                  <div className="text-base sm:text-lg font-semibold">
-                    {new Date().toLocaleTimeString('ko-KR', { 
-                      hour: '2-digit', 
-                      minute: '2-digit' 
-                    })}
-                  </div>
+              <div>
+                <div className="text-lg font-bold text-white flex items-center gap-2">
+                  {userName} 상담사님 <span className="animate-bounce">👋</span>
                 </div>
-                <div className="w-12 h-12 sm:w-16 sm:h-16 bg-white/20 rounded-full flex items-center justify-center">
-                  <div className="w-8 h-8 sm:w-12 sm:h-12 bg-white/30 rounded-full flex items-center justify-center text-lg sm:text-xl font-bold">
-                    {consultantData.name.substring(0, 1)}
-                  </div>
-                </div>
-              </div>
-              <div className="flex sm:hidden">
-                <div className="w-10 h-10 bg-white/20 rounded-full flex items-center justify-center">
-                  <div className="w-8 h-8 bg-white/30 rounded-full flex items-center justify-center text-sm font-bold">
-                    {consultantData.name.substring(0, 1)}
-                  </div>
+                <div className="text-sm text-pink-100 mt-1">
+                  오늘도 힘내세요! Feple이 함께합니다 :)
                 </div>
               </div>
             </div>
+            {/* 전일 상담 분석 카드 */}
+            <div className="bg-white rounded-2xl p-6 shadow-sm border border-gray-100 flex flex-col gap-2">
+              <div className="text-lg font-semibold text-pink-600 mb-2">
+                어제 상담 분석 요약
+              </div>
+              <ul className="text-sm text-gray-700 list-disc pl-5 space-y-1">
+                <li>
+                  <span className="font-bold">강점:</span>{" "}
+                  {yesterdayAnalysis.strengths}
+                </li>
+                <li>
+                  <span className="font-bold">개선점:</span>{" "}
+                  {yesterdayAnalysis.improvements}
+                </li>
+                <li>
+                  <span className="font-bold">코칭 멘트:</span>{" "}
+                  {yesterdayAnalysis.coaching}
+                </li>
+              </ul>
+            </div>
+            {/* 전일 평균 점수 카드 */}
+            <div className="bg-white rounded-2xl p-6 shadow-md border border-gray-100 flex flex-col items-center justify-center">
+              <div className="text-base text-gray-500 mb-1">어제 평균 점수</div>
+              <div className="text-4xl font-bold text-pink-600">
+                {yesterdayAvgScore}점
+              </div>
+              <div className="text-xs text-gray-400 mt-1">
+                어제 상담의 종합 점수예요!
+              </div>
+            </div>
+            {/* 위험 지표 카드 2개 */}
+            {lowIndicators.map((item) => (
+              <div
+                key={item.label}
+                className="bg-white rounded-2xl p-4 shadow-md border border-gray-100 flex items-center gap-4"
+              >
+                <div className="text-lg font-semibold">{item.label}</div>
+                <div className="ml-auto flex items-center gap-2">
+                  <span className="text-2xl font-bold">{item.grade}</span>
+                  <span
+                    className={
+                      "h-4 w-4 rounded-full inline-block border border-white animate-blink"
+                    }
+                    style={{
+                      backgroundColor:
+                        item.grade === "G"
+                          ? "#ef4444"
+                          : item.grade === "C"
+                          ? "#facc15"
+                          : "#4ade80",
+                    }}
+                  ></span>
+                </div>
+                <span className="ml-3 text-xs text-pink-500 font-semibold">
+                  조금 더 신경 써주세요!
+                </span>
+              </div>
+            ))}
           </div>
-
-          {/* 오늘의 성과 메트릭 */}
-          <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4 lg:gap-6">
-            <div className="bg-white rounded-xl p-3 sm:p-4 lg:p-6 shadow-sm border border-gray-200">
-              <div className="flex items-center justify-between mb-2">
-                <div className="text-xs sm:text-sm text-gray-600">오늘</div>
-                <MessageCircle className="h-4 w-4 sm:h-5 sm:w-5 text-blue-500" />
-              </div>
-              <div className="text-xl sm:text-2xl lg:text-3xl font-bold text-gray-900 mb-1">
-                {todayStats.callsCompleted}
-              </div>
-              <div className="text-xs sm:text-sm text-gray-600">완료된 상담</div>
+          {/* 오른쪽 차트 */}
+          {/* 수정: h-96 -> h-full */}
+          <div className="bg-white rounded-2xl p-4 shadow-lg border border-gray-100 flex flex-col justify-center h-full">
+            <div className="text-lg font-semibold text-gray-800 mb-0 text-center">
+              종합 역량 분석
             </div>
-
-            <div className="bg-white rounded-xl p-3 sm:p-4 lg:p-6 shadow-sm border border-gray-200">
-              <div className="flex items-center justify-between mb-2">
-                <div className="text-xs sm:text-sm text-gray-600">평균</div>
-                <Clock className="h-4 w-4 sm:h-5 sm:w-5 text-green-500" />
-              </div>
-              <div className="text-xl sm:text-2xl lg:text-3xl font-bold text-gray-900 mb-1">
-                {todayStats.avgCallDuration}
-              </div>
-              <div className="text-xs sm:text-sm text-gray-600">상담 시간</div>
+            {/* 수정: h-96 -> h-full */}
+            <div className="h-full flex items-center justify-center">
+              <RadarChart data={radarData} />
             </div>
-
-            <div className="bg-white rounded-xl p-3 sm:p-4 lg:p-6 shadow-sm border border-gray-200">
-              <div className="flex items-center justify-between mb-2">
-                <div className="text-xs sm:text-sm text-gray-600">평점</div>
-                <Award className="h-4 w-4 sm:h-5 sm:w-5 text-yellow-500" />
-              </div>
-              <div className="text-xl sm:text-2xl lg:text-3xl font-bold text-gray-900 mb-1">
-                {todayStats.satisfactionScore}
-              </div>
-              <div className="text-xs sm:text-sm text-gray-600">만족도 (5점 만점)</div>
-            </div>
-
-            <div className="bg-white rounded-xl p-3 sm:p-4 lg:p-6 shadow-sm border border-gray-200">
-              <div className="flex items-center justify-between mb-2">
-                <div className="text-xs sm:text-sm text-gray-600">해결율</div>
-                <TrendingUp className="h-4 w-4 sm:h-5 sm:w-5 text-purple-500" />
-              </div>
-              <div className="text-xl sm:text-2xl lg:text-3xl font-bold text-gray-900 mb-1">
-                91%
-              </div>
-              <div className="text-xs sm:text-sm text-gray-600">문제 해결</div>
-            </div>
-          </div>
-
-          {/* 메인 콘텐츠 영역 */}
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 sm:gap-6 h-full lg:h-[calc(100vh-28rem)]">
-            {/* 이번 주 성과 */}
-            <div className="bg-white rounded-xl p-4 sm:p-6 shadow-sm border border-gray-200 flex flex-col">
-              <div className="flex items-center gap-2 mb-4">
-                <BarChart3 className="h-5 w-5 text-blue-500" />
-                <h2 className="text-base sm:text-lg font-semibold text-gray-800">이번 주 성과</h2>
-              </div>
-              
-              <div className="space-y-4 sm:space-y-6 flex-1">
-                <div className="flex items-center justify-between">
-                  <span className="text-sm sm:text-base text-gray-600">총 상담 건수</span>
-                  <span className="text-lg sm:text-xl font-bold text-gray-900">{weeklyPerformance.totalCalls}건</span>
-                </div>
-                
-                <div className="flex items-center justify-between">
-                  <span className="text-sm sm:text-base text-gray-600">평균 만족도</span>
-                  <span className="text-lg sm:text-xl font-bold text-gray-900">{weeklyPerformance.avgSatisfaction}</span>
-                </div>
-                
-                <div className="flex items-center justify-between">
-                  <span className="text-sm sm:text-base text-gray-600">개선율</span>
-                  <span className="text-lg sm:text-xl font-bold text-green-600">{weeklyPerformance.improvementRate}</span>
-                </div>
-                
-                <div className="flex items-center justify-between">
-                  <span className="text-sm sm:text-base text-gray-600">팀 내 순위</span>
-                  <span className="text-lg sm:text-xl font-bold text-gray-900">{weeklyPerformance.rankInTeam}위</span>
-                </div>
-              </div>
-            </div>
-
-            {/* 최근 피드백 */}
-            <div className="bg-white rounded-xl p-4 sm:p-6 shadow-sm border border-gray-200 flex flex-col">
-              <div className="flex items-center gap-2 mb-4">
-                <MessageCircle className="h-5 w-5 text-green-500" />
-                <h2 className="text-base sm:text-lg font-semibold text-gray-800">최근 피드백</h2>
-              </div>
-              
-              <div className="space-y-3 sm:space-y-4 flex-1 overflow-y-auto">
-                <div className="bg-green-50 border border-green-200 rounded-lg p-3 sm:p-4">
-                  <div className="flex items-center gap-2 mb-2">
-                    <div className="w-2 h-2 bg-green-500 rounded-full"></div>
-                    <span className="text-xs sm:text-sm font-medium text-green-700">QC 평가</span>
-                    <span className="text-xs text-green-600 ml-auto">2시간 전</span>
-                  </div>
-                  <p className="text-sm sm:text-base text-green-800 leading-relaxed">
-                    고객 응대 시 공감대 형성과 정확한 해결책 제시. 체계적인 과정 응대로 자연스러운 대화를 유도했습니다.
-                  </p>
-                </div>
-
-                <div className="bg-blue-50 border border-blue-200 rounded-lg p-3 sm:p-4">
-                  <div className="flex items-center gap-2 mb-2">
-                    <div className="w-2 h-2 bg-blue-500 rounded-full"></div>
-                    <span className="text-xs sm:text-sm font-medium text-blue-700">고객 후기</span>
-                    <span className="text-xs text-blue-600 ml-auto">1일 전</span>
-                  </div>
-                                     <p className="text-sm sm:text-base text-blue-800 leading-relaxed">
-                     &ldquo;질문에 대한 정확한 답변과 친절한 진행인 문제를 해결해 주셔서 감사합니다!&rdquo;
-                   </p>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          {/* 개발 진행 중 알림 */}
-          <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4 sm:p-6">
-            <div className="flex items-center gap-2 mb-2">
-              <AlertCircle className="h-5 w-5 text-yellow-600" />
-              <h3 className="text-base sm:text-lg font-semibold text-yellow-800">🚧 개발 진행 중</h3>
-            </div>
-            <p className="text-sm sm:text-base text-yellow-700">
-              상담사 전용 대시보드가 현재 개발 중입니다. 곧 더 많은 기능들을 만나보실 수 있습니다!
-            </p>
           </div>
         </div>
       </div>
     </DashboardLayout>
   );
-} 
+}

--- a/src/components/charts/RadarChart.tsx
+++ b/src/components/charts/RadarChart.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import React from 'react';
+import {
+  Radar,
+  RadarChart as RechartsRadarChart,
+  PolarGrid,
+  PolarAngleAxis,
+  PolarRadiusAxis,
+  ResponsiveContainer,
+} from 'recharts';
+import { cn } from '@/lib/utils';
+
+interface RadarChartProps {
+  data: {
+    subject: string;
+    A: number;
+    fullMark?: number;
+  }[];
+  className?: string;
+}
+
+export function RadarChart({ data, className }: RadarChartProps) {
+  return (
+    <div className={cn("w-full h-full", className)}>
+      <ResponsiveContainer width="100%" height="100%">
+        <RechartsRadarChart cx="50%" cy="50%" outerRadius="80%" data={data}>
+          <PolarGrid stroke="#E5E7EB" />
+          <PolarAngleAxis 
+            dataKey="subject"
+            tick={{
+              fill: '#4B5563',
+              fontSize: 12,
+              fontWeight: 500,
+            }}
+          />
+          <PolarRadiusAxis angle={30} domain={[0, 5]} />
+          <Radar
+            name="역할 분석"
+            dataKey="A"
+            stroke="#8B5CF6"
+            fill="#8B5CF6"
+            fillOpacity={0.3}
+            strokeWidth={2}
+            dot={{
+              fill: '#8B5CF6',
+              r: 4,
+              strokeWidth: 2,
+              stroke: '#fff',
+            }}
+          />
+        </RechartsRadarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/styles/animations.css
+++ b/src/styles/animations.css
@@ -43,11 +43,33 @@
 }
 
 @keyframes pulse-glow {
-  0%, 100% {
+  0%,
+  100% {
     box-shadow: 0 0 20px rgba(236, 72, 153, 0.3);
   }
   50% {
     box-shadow: 0 0 30px rgba(236, 72, 153, 0.5);
+  }
+}
+
+@keyframes blink {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.2;
+  }
+}
+
+@keyframes slide-fade-down {
+  0% {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
   }
 }
 
@@ -73,6 +95,14 @@
   animation: pulse-glow 2s ease-in-out infinite;
 }
 
+.animate-blink {
+  animation: blink 1s infinite;
+}
+
+.animate-slide-fade-down {
+  animation: slide-fade-down 0.7s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
 /* ===== TRANSITION UTILITIES ===== */
 
 .transition-theme {
@@ -88,7 +118,8 @@
 }
 
 .transition-colors {
-  transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
+  transition: background-color 0.3s ease, color 0.3s ease,
+    border-color 0.3s ease;
 }
 
 .transition-transform {
@@ -138,10 +169,15 @@
 }
 
 @keyframes bounce {
-  0%, 20%, 53%, 80%, 100% {
+  0%,
+  20%,
+  53%,
+  80%,
+  100% {
     transform: translate3d(0, 0, 0);
   }
-  40%, 43% {
+  40%,
+  43% {
     transform: translate3d(0, -8px, 0);
   }
   70% {
@@ -160,6 +196,25 @@
   animation: bounce 1s ease infinite;
 }
 
+@keyframes shake {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  20%,
+  60% {
+    transform: translateX(-4px);
+  }
+  40%,
+  80% {
+    transform: translateX(4px);
+  }
+}
+
+.animate-shake {
+  animation: shake 0.6s infinite;
+}
+
 /* ===== RESPONSIVE ANIMATIONS ===== */
 
 @media (prefers-reduced-motion: reduce) {
@@ -170,4 +225,4 @@
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
   }
-} 
+}


### PR DESCRIPTION
## 주요 변경사항

- 상담사 대시보드(consultant/page.tsx) 전체 레이아웃 및 UI/UX 전면 개선
- 한 화면에서 모든 주요 정보가 스크롤 없이 자연스럽게 보이도록 구조 최적화
- 최상위 컨테이너, 내부 그리드, 카드, 차트의 패딩/마진/여백/크기/정렬 등 세밀하게 조정
- 인사말 카드, 분석 카드, 점수 카드, 위험지표 카드, 차트 등 각 요소별 시각적 일관성 및 가독성 향상
- 반응형 대응 및 세로/가로 정렬 최적화
- 여백이 너무 많거나 적은 문제, 세로/가로 정렬 불균형 문제 해결

## 개선 전/후 비교

- **개선 전**: 여백이 과하거나 부족, 정보가 한 화면에 다 들어오지 않거나 정렬이 어색함
- **개선 후**: 한 화면에 모든 정보가 보기 좋게 들어오고, 여백과 정렬이 균형 있게 맞춰짐

## 기타

- 추가적인 UI/UX 피드백이 있을 경우, 카드/차트 크기 및 여백 등은 쉽게 조정 가능
- 코드 구조는 유지하면서 스타일 위주로 개선