### PR TITLE
fix: Wrapped useSearchParams() in Suspense for proper SSR handling

### DIFF
--- a/src/app/consultant/performance/page.tsx
+++ b/src/app/consultant/performance/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, Suspense } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import DashboardLayout from "@/components/DashboardLayout";
 import {
@@ -12,7 +12,7 @@ import {
   ConversationDetail,
 } from "@/components/features/performance";
 
-export default function ConsultantPerformancePage() {
+function ConsultantPerformanceContent() {
   const searchParams = useSearchParams();
   const router = useRouter();
 
@@ -132,5 +132,13 @@ export default function ConsultantPerformancePage() {
         </div>
       </div>
     </DashboardLayout>
+  );
+}
+
+export default function ConsultantPerformancePage() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <ConsultantPerformanceContent />
+    </Suspense>
   );
 }


### PR DESCRIPTION
### 변경 사항
- `useSearchParams()`를 `Suspense`로 감싸서 서버 사이드 렌더링 문제 해결