### PR TITLE
feat(qc): QC 대시보드 UI/UX 개선

### DIFF
--- a/src/app/consultant/upload/page.tsx
+++ b/src/app/consultant/upload/page.tsx
@@ -89,7 +89,7 @@ export default function UploadPage() {
                   </div>
                 )}
 
-                <div className="w-full flex justify-end mt-4">
+                <div className="w-full flex justify-end mt-4 text-white">
                   <Button
                     onClick={handleUploadAndAnalyze}
                     disabled={!selectedFile || isLoading}

--- a/src/app/qc/page.tsx
+++ b/src/app/qc/page.tsx
@@ -2,151 +2,56 @@
 
 import { useState } from "react";
 import DashboardLayout from "@/components/DashboardLayout";
-import { Users, Search, Filter, ChevronRight, AlertTriangle, ChevronDown, Clock, ChevronLeft } from "lucide-react";
+import {
+  Users,
+  Search,
+  ChevronRight,
+  AlertTriangle,
+  ChevronDown,
+  Clock,
+  ChevronLeft,
+} from "lucide-react";
+import {
+  searchData,
+  teams,
+  teamMembers,
+  inspectionRecommendations,
+  riskAlerts,
+} from "@/data/qcData";
 
-export default function DashboardPage() {
+export default function QCDashboardPage() {
   const [searchTerm, setSearchTerm] = useState("");
   const [showResults, setShowResults] = useState(false);
   const [selectedTeam, setSelectedTeam] = useState<string>("");
   const [isTeamDropdownOpen, setIsTeamDropdownOpen] = useState(false);
   const [riskAlertPage, setRiskAlertPage] = useState(0);
   const [inspectionPage, setInspectionPage] = useState(0);
+  const [teamMemberPage, setTeamMemberPage] = useState(0);
 
-  // 검색 데이터 (업데이트된 정적 데이터)
-  const searchData = [
-    { type: "consultant", title: "김민수", subtitle: "고객상담 1팀 - 선임 상담사", link: "/consultants", score: 4.8 },
-    { type: "consultant", title: "이영희", subtitle: "고객상담 2팀 - 상담사", link: "/consultants", score: 4.5 },
-    { type: "consultant", title: "박성호", subtitle: "고객상담 1팀 - 상담사", link: "/consultants", score: 4.2 },
-    { type: "consultant", title: "최미연", subtitle: "고객상담 3팀 - 팀장", link: "/consultants", score: 4.9 },
-    { type: "consultant", title: "노준석", subtitle: "고객상담 1팀 - 상담사", link: "/consultants", score: 3.2 },
-  ];
+  // QC 정보
+  const qcName = "김민준";
+  const qcInitial = qcName[0];
 
-  // 팀 데이터
-  const teams = [
-    { id: "team1", name: "고객상담 1팀", memberCount: 12, teamLead: "김팀장" },
-    { id: "team2", name: "고객상담 2팀", memberCount: 15, teamLead: "이팀장" },
-    { id: "team3", name: "고객상담 3팀", memberCount: 10, teamLead: "박팀장" },
-    { id: "team4", name: "기술지원팀", memberCount: 8, teamLead: "최팀장" },
-  ];
+  // 오늘 날짜 (2025-07-17)
+  const today = new Date("2025-07-17");
 
-  // 팀별 상담원 데이터
-  const teamMembers = {
-    team1: [
-      { id: "c1", name: "김민수", position: "선임 상담사", status: "활동", callsToday: 23, satisfactionScore: 4.8 },
-      { id: "c2", name: "박성호", position: "상담사", status: "활동", callsToday: 18, satisfactionScore: 4.2 },
-      { id: "c3", name: "임지원", position: "상담사", status: "휴식", callsToday: 15, satisfactionScore: 4.5 },
-      { id: "c12", name: "노준석", position: "상담사", status: "활동", callsToday: 12, satisfactionScore: 3.2 },
-    ],
-    team2: [
-      { id: "c4", name: "이영희", position: "상담사", status: "활동", callsToday: 20, satisfactionScore: 4.5 },
-      { id: "c5", name: "정다은", position: "상담사", status: "활동", callsToday: 16, satisfactionScore: 4.3 },
-      { id: "c6", name: "강현준", position: "선임 상담사", status: "활동", callsToday: 25, satisfactionScore: 4.7 },
-    ],
-    team3: [
-      { id: "c7", name: "최미연", position: "팀장", status: "활동", callsToday: 12, satisfactionScore: 4.9 },
-      { id: "c8", name: "한상욱", position: "상담사", status: "활동", callsToday: 19, satisfactionScore: 4.4 },
-      { id: "c9", name: "송예진", position: "상담사", status: "휴식", callsToday: 14, satisfactionScore: 4.6 },
-    ],
-    team4: [
-      { id: "c10", name: "윤진호", position: "기술지원", status: "활동", callsToday: 8, satisfactionScore: 4.8 },
-      { id: "c11", name: "조은실", position: "기술지원", status: "활동", callsToday: 10, satisfactionScore: 4.5 },
-    ],
+  // 경과 일수 계산 함수
+  const calculateDaysDiff = (dateString: string): number => {
+    const targetDate = new Date(dateString);
+    const diffTime = today.getTime() - targetDate.getTime();
+    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+    return diffDays;
   };
 
-  // 점검 추천 상담사 데이터
-  const inspectionRecommendations = [
-    {
-      id: "c15",
-      name: "문지호",
-      team: "고객상담 1팀",
-      position: "상담사",
-      lastInspection: "2024-11-15",
-      daysSinceInspection: 38,
-      recommendationReason: "정기 점검 주기 초과",
-      priority: "high",
-      qcManager: "김QC"
-    },
-    {
-      id: "c16", 
-      name: "서민정",
-      team: "고객상담 2팀",
-      position: "선임 상담사",
-      lastInspection: "2024-12-01",
-      daysSinceInspection: 22,
-      recommendationReason: "성과 개선 모니터링",
-      priority: "medium",
-      qcManager: "이QC"
-    },
-    {
-      id: "c17",
-      name: "조현우",
-      team: "기술지원팀",
-      position: "기술지원",
-      lastInspection: "2024-10-28",
-      daysSinceInspection: 56,
-      recommendationReason: "장기 미점검",
-      priority: "high",
-      qcManager: "박QC"
-    },
-    {
-      id: "c18",
-      name: "배수진",
-      team: "고객상담 3팀",
-      position: "상담사",
-      lastInspection: "2024-12-10",
-      daysSinceInspection: 13,
-      recommendationReason: "신규 교육 후 점검",
-      priority: "low",
-      qcManager: "최QC"
-    }
-  ];
-
-  // 위험 등급 상담사 데이터
-  const riskAlerts = [
-    {
-      id: "c12",
-      name: "노준석",
-      team: "고객상담 1팀",
-      position: "상담사",
-      riskCategories: [
-        { category: "공감적 소통", grade: "F", severity: "critical" },
-        { category: "정중함", grade: "G", severity: "warning" }
-      ],
-      lastEvaluation: "2024-12-23 14:30",
-      actionRequired: true
-    },
-    {
-      id: "c13",
-      name: "김철호",
-      team: "고객상담 2팀", 
-      position: "상담사",
-      riskCategories: [
-        { category: "문제 해결", grade: "F", severity: "critical" }
-      ],
-      lastEvaluation: "2024-12-23 13:15",
-      actionRequired: true
-    },
-    {
-      id: "c14",
-      name: "이수정",
-      team: "기술지원팀",
-      position: "기술지원",
-      riskCategories: [
-        { category: "감정 안정성", grade: "G", severity: "warning" },
-        { category: "대화 흐름", grade: "F", severity: "critical" }
-      ],
-      lastEvaluation: "2024-12-23 12:45",
-      actionRequired: true
-    }
-  ];
-
   // 검색 결과 필터링
-  const searchResults = searchTerm.length > 0 
-    ? searchData.filter(item =>
-        item.title.includes(searchTerm) ||
-        item.subtitle.includes(searchTerm)
-      )
-    : [];
+  const searchResults =
+    searchTerm.length > 0
+      ? searchData.filter(
+          (item) =>
+            item.title.includes(searchTerm) ||
+            item.subtitle.includes(searchTerm)
+        )
+      : [];
 
   const handleSearchChange = (value: string) => {
     setSearchTerm(value);
@@ -154,7 +59,8 @@ export default function DashboardPage() {
   };
 
   const getTypeIcon = (type: string) => {
-    if (type === "consultant") return <Users className="h-4 w-4 text-blue-500" />;
+    if (type === "consultant")
+      return <Users className="h-4 w-4 text-blue-500" />;
     return <Search className="h-4 w-4 text-gray-500" />;
   };
 
@@ -163,39 +69,44 @@ export default function DashboardPage() {
     return "기타";
   };
 
-  const handleConsultantClick = (consultant: { id: string; name: string; position: string; status: string; callsToday: number; satisfactionScore: number } | { type: string; title: string; subtitle: string; link: string; score: number }) => {
+  const handleConsultantClick = (
+    consultant:
+      | {
+          id: string;
+          name: string;
+          position: string;
+          callsToday: number;
+        }
+      | {
+          type: string;
+          title: string;
+          subtitle: string;
+          link: string;
+        }
+  ) => {
     // 상담 모니터링 페이지로 이동
-    if ('id' in consultant) {
+    if ("id" in consultant) {
       window.location.href = `/performance?consultant=${consultant.id}`;
     } else {
       window.location.href = `/performance?consultant=${consultant.title}`;
     }
   };
 
-  const handleRiskAlertClick = (alert: typeof riskAlerts[0]) => {
+  const handleRiskAlertClick = (alert: (typeof riskAlerts)[0]) => {
     window.location.href = `/performance?consultant=${alert.id}`;
   };
 
-  const handleInspectionRecommendationClick = (recommendation: typeof inspectionRecommendations[0]) => {
+  const handleInspectionRecommendationClick = (
+    recommendation: (typeof inspectionRecommendations)[0]
+  ) => {
     window.location.href = `/performance?consultant=${recommendation.id}`;
-  };
-
-  const getStatusColor = (status: string) => {
-    switch (status) {
-      case "활동":
-        return "bg-green-100 text-green-800";
-      case "휴식":
-        return "bg-yellow-100 text-yellow-800";
-      default:
-        return "bg-gray-100 text-gray-800";
-    }
   };
 
   const getGradeColor = (grade: string, severity: string) => {
     if (severity === "critical") {
-      return "bg-red-500 text-white";
+      return "bg-red-500 text-white animate-pulse";
     } else if (severity === "warning") {
-      return "bg-orange-500 text-white";
+      return "bg-orange-500 text-white animate-pulse";
     }
     return "bg-gray-500 text-white";
   };
@@ -238,11 +149,14 @@ export default function DashboardPage() {
   const handleTeamSelect = (teamId: string) => {
     setSelectedTeam(teamId);
     setIsTeamDropdownOpen(false);
+    setTeamMemberPage(0); // 팀 변경시 페이지 리셋
   };
 
   const getSelectedTeamName = () => {
     if (!selectedTeam) return "팀을 선택하세요";
-    return teams.find(team => team.id === selectedTeam)?.name || "팀을 선택하세요";
+    return (
+      teams.find((team) => team.id === selectedTeam)?.name || "팀을 선택하세요"
+    );
   };
 
   const getCurrentTeamMembers = () => {
@@ -252,18 +166,20 @@ export default function DashboardPage() {
 
   // 점검 추천 상담사 페이지네이션
   const ITEMS_PER_PAGE = 2;
-  const inspectionTotalPages = Math.ceil(inspectionRecommendations.length / ITEMS_PER_PAGE);
+  const inspectionTotalPages = Math.ceil(
+    inspectionRecommendations.length / ITEMS_PER_PAGE
+  );
   const paginatedInspectionRecommendations = inspectionRecommendations.slice(
     inspectionPage * ITEMS_PER_PAGE,
     (inspectionPage + 1) * ITEMS_PER_PAGE
   );
 
   const handleInspectionPrevPage = () => {
-    setInspectionPage(prev => Math.max(0, prev - 1));
+    setInspectionPage((prev) => Math.max(0, prev - 1));
   };
 
   const handleInspectionNextPage = () => {
-    setInspectionPage(prev => Math.min(inspectionTotalPages - 1, prev + 1));
+    setInspectionPage((prev) => Math.min(inspectionTotalPages - 1, prev + 1));
   };
 
   // 위험 등급 알림 페이지네이션
@@ -274,336 +190,453 @@ export default function DashboardPage() {
   );
 
   const handlePrevPage = () => {
-    setRiskAlertPage(prev => Math.max(0, prev - 1));
+    setRiskAlertPage((prev) => Math.max(0, prev - 1));
   };
 
   const handleNextPage = () => {
-    setRiskAlertPage(prev => Math.min(totalPages - 1, prev + 1));
+    setRiskAlertPage((prev) => Math.min(totalPages - 1, prev + 1));
+  };
+
+  // 팀별 상담원 페이지네이션
+  const currentTeamMembers = getCurrentTeamMembers();
+  const teamTotalPages = Math.ceil(currentTeamMembers.length / ITEMS_PER_PAGE);
+  const paginatedTeamMembers = currentTeamMembers.slice(
+    teamMemberPage * ITEMS_PER_PAGE,
+    (teamMemberPage + 1) * ITEMS_PER_PAGE
+  );
+
+  const handleTeamPrevPage = () => {
+    setTeamMemberPage((prev) => Math.max(0, prev - 1));
+  };
+
+  const handleTeamNextPage = () => {
+    setTeamMemberPage((prev) => Math.min(teamTotalPages - 1, prev + 1));
   };
 
   return (
     <DashboardLayout>
-      <div className="h-full space-y-4 sm:space-y-6 text-gray-900">
-        {/* 환영 메시지 */}
-        <div className="bg-gradient-to-r from-pink-500 to-purple-600 rounded-xl sm:rounded-2xl p-4 sm:p-6 text-white shadow-xl welcome-white-text">
-          <div className="flex items-center justify-between">
-            <div className="flex-1">
-              <h2 className="text-lg sm:text-xl lg:text-2xl font-bold mb-2">안녕하세요, 관리자님! 👋</h2>
-              <p className="text-sm sm:text-base text-white">팀별 상담원 모니터링을 통해 효율적인 관리를 도와드리겠습니다.</p>
+      <div className="w-full h-full bg-gradient-to-br from-pink-50 via-purple-50 to-indigo-50 p-3">
+        <div className="space-y-3">
+          {/* 인사말 카드 */}
+          <div className="bg-gradient-to-r from-pink-400 to-purple-400 rounded-xl p-4 shadow-lg flex items-center gap-3 animate-pulse-glow">
+            <div className="h-10 w-10 rounded-full bg-white/30 flex items-center justify-center text-lg font-bold text-white shadow">
+              {qcInitial}
             </div>
-            <div className="hidden md:block">
-              <div className="w-16 h-16 lg:w-24 lg:h-24 bg-white/20 rounded-full flex items-center justify-center">
-                <Users className="w-8 h-8 lg:w-12 lg:h-12 text-white" />
+            <div>
+              <div className="text-base font-bold text-white flex items-center gap-2">
+                {qcName} QC님 <span className="animate-bounce">👋🏻</span>
+              </div>
+              <div className="text-xs text-pink-100 mt-1">
+                오늘도 힘내세요! Feple이 함께합니다 :)
               </div>
             </div>
           </div>
-        </div>
 
-        {/* 전역 검색 */}
-        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4 sm:p-6">
-          <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-4">
-            <div className="flex-1 relative">
+          {/* 검색 섹션 */}
+          <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-3">
+            <div className="relative">
               <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
               <input
                 type="text"
                 placeholder="상담사 이름으로 검색..."
                 value={searchTerm}
                 onChange={(e) => handleSearchChange(e.target.value)}
-                className="w-full pl-10 pr-4 py-2 sm:py-3 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-pink-500 text-base sm:text-lg"
+                className="w-full pl-10 pr-4 py-2 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-pink-500 text-sm"
               />
             </div>
-            <button className="flex items-center justify-center gap-2 px-4 py-2 sm:py-3 border border-gray-200 rounded-lg hover:bg-gray-50 text-gray-700 whitespace-nowrap">
-              <Filter className="h-4 w-4" />
-              필터
-            </button>
-          </div>
 
-          {/* 검색 결과 */}
-          {showResults && (
-            <div className="mt-4 border-t border-gray-200 pt-4">
-              <h4 className="text-sm font-medium text-gray-700 mb-3">검색 결과 ({searchResults.length}개)</h4>
-              {searchResults.length > 0 ? (
-                <div className="space-y-2">
-                  {searchResults.slice(0, 6).map((result, index) => (
-                    <div
-                      key={index}
-                      onClick={() => result.type === "consultant" && handleConsultantClick(result)}
-                      className="flex items-center gap-3 p-3 rounded-lg hover:bg-gray-50 transition-colors cursor-pointer"
-                    >
-                      {getTypeIcon(result.type)}
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-2">
-                          <span className="font-medium text-gray-900 truncate">{result.title}</span>
-                          <span className="px-2 py-1 bg-gray-100 text-gray-600 text-xs rounded-full whitespace-nowrap">
-                            {getTypeName(result.type)}
-                          </span>
-                        </div>
-                        <p className="text-sm text-gray-500 truncate">{result.subtitle}</p>
-                      </div>
-                      {result.score && (
-                        <div className="text-sm font-medium text-gray-900 whitespace-nowrap">
-                          ⭐ {result.score}
-                        </div>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <p className="text-gray-500 text-center py-4">검색 결과가 없습니다.</p>
-              )}
-            </div>
-          )}
-        </div>
-
-        {/* 3열 레이아웃 - 완전 반응형 */}
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 sm:gap-6 h-full lg:h-[calc(100vh-24rem)]">
-          
-          {/* 첫 번째: 점검 추천 상담사 */}
-          <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4 sm:p-6 flex flex-col h-full">
-            <div className="flex items-center gap-2 mb-4">
-              <Clock className="h-5 w-5 text-blue-500" />
-              <h3 className="text-base sm:text-lg font-semibold text-gray-800">점검 추천 상담사</h3>
-              <span className="bg-blue-100 text-blue-800 text-xs font-medium px-2 py-1 rounded-full">
-                {inspectionRecommendations.length}건
-              </span>
-            </div>
-            
-            <div className="space-y-3 overflow-y-auto flex-1">
-              {paginatedInspectionRecommendations.map((recommendation) => (
-                <div 
-                  key={recommendation.id}
-                  onClick={() => handleInspectionRecommendationClick(recommendation)}
-                  className="border border-blue-200 rounded-lg p-3 sm:p-4 hover:bg-blue-50 transition-colors cursor-pointer"
-                >
-                  <div className="flex items-start justify-between mb-2">
-                    <div className="flex-1 min-w-0">
-                      <h4 className="font-semibold text-gray-900 truncate">{recommendation.name}</h4>
-                      <p className="text-sm text-gray-600 truncate">{recommendation.team} - {recommendation.position}</p>
-                    </div>
-                    <span className={`px-2 py-1 text-xs font-medium rounded-full whitespace-nowrap ml-2 ${getPriorityColor(recommendation.priority)}`}>
-                      {getPriorityText(recommendation.priority)}
-                    </span>
-                  </div>
-                  
-                  <div className="space-y-1 mb-3">
-                    <div className="flex items-center justify-between text-sm">
-                      <span className="text-gray-600">마지막 점검</span>
-                      <span className="text-gray-800 text-xs sm:text-sm">{recommendation.lastInspection}</span>
-                    </div>
-                    <div className="flex items-center justify-between text-sm">
-                      <span className="text-gray-600">경과 일수</span>
-                      <span className={`font-medium ${recommendation.daysSinceInspection > 30 ? 'text-red-600' : 'text-gray-800'}`}>
-                        {recommendation.daysSinceInspection}일
-                      </span>
-                    </div>
-                    <div className="flex items-center justify-between text-sm">
-                      <span className="text-gray-600">담당 QC</span>
-                      <span className="text-gray-800 truncate">{recommendation.qcManager}</span>
-                    </div>
-                  </div>
-                  
-                  <div className="text-xs text-gray-600 bg-gray-50 rounded p-2">
-                    {recommendation.recommendationReason}
-                  </div>
-                </div>
-              ))}
-            </div>
-            
-            {/* 페이지네이션 */}
-            {inspectionTotalPages > 1 && (
-              <div className="flex items-center justify-between mt-4 pt-4 border-t border-gray-200">
-                <button
-                  onClick={handleInspectionPrevPage}
-                  disabled={inspectionPage === 0}
-                  className={`flex items-center gap-2 px-3 py-1 rounded-lg text-sm ${
-                    inspectionPage === 0
-                      ? 'text-gray-400 cursor-not-allowed'
-                      : 'text-gray-700 hover:bg-gray-100'
-                  }`}
-                >
-                  <ChevronLeft className="h-4 w-4" />
-                  이전
-                </button>
-                
-                <span className="text-sm text-gray-600">
-                  {inspectionPage + 1} / {inspectionTotalPages}
-                </span>
-                
-                <button
-                  onClick={handleInspectionNextPage}
-                  disabled={inspectionPage === inspectionTotalPages - 1}
-                  className={`flex items-center gap-2 px-3 py-1 rounded-lg text-sm ${
-                    inspectionPage === inspectionTotalPages - 1
-                      ? 'text-gray-400 cursor-not-allowed'
-                      : 'text-gray-700 hover:bg-gray-100'
-                  }`}
-                >
-                  다음
-                  <ChevronRight className="h-4 w-4" />
-                </button>
-              </div>
-            )}
-          </div>
-
-          {/* 두 번째: 위험 등급 알림 (페이지네이션 적용) */}
-          <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4 sm:p-6 flex flex-col h-full">
-            <div className="flex items-center gap-2 mb-4">
-              <AlertTriangle className="h-5 w-5 text-red-500" />
-              <h3 className="text-base sm:text-lg font-semibold text-gray-800">위험 등급 알림</h3>
-              <span className="bg-red-100 text-red-800 text-xs font-medium px-2 py-1 rounded-full">
-                {riskAlerts.length}건
-              </span>
-            </div>
-            
-            <div className="space-y-4 mb-4 flex-1 overflow-y-auto">
-              {paginatedRiskAlerts.map((alert) => (
-                <div 
-                  key={alert.id}
-                  onClick={() => handleRiskAlertClick(alert)}
-                  className="border border-red-200 rounded-lg p-3 sm:p-4 hover:bg-red-50 transition-colors cursor-pointer"
-                >
-                  <div className="flex items-start justify-between mb-3">
-                    <div className="flex-1 min-w-0">
-                      <h4 className="font-semibold text-gray-900 truncate">{alert.name}</h4>
-                      <p className="text-sm text-gray-600 truncate">{alert.team} - {alert.position}</p>
-                    </div>
-                    <div className="flex items-center gap-1 ml-2">
-                      {getSeverityIcon(alert.riskCategories[0].severity)}
-                      <span className="text-xs text-gray-500 whitespace-nowrap">긴급</span>
-                    </div>
-                  </div>
-                  
-                  <div className="space-y-2 mb-3">
-                    {alert.riskCategories.map((risk, index) => (
-                      <div key={index} className="flex items-center justify-between">
-                        <span className="text-sm text-gray-700 truncate">{risk.category}</span>
-                        <span className={`px-2 py-1 text-xs font-bold rounded whitespace-nowrap ${getGradeColor(risk.grade, risk.severity)}`}>
-                          {risk.grade}
-                        </span>
-                      </div>
-                    ))}
-                  </div>
-                  
-                  <div className="text-xs text-gray-600 bg-gray-50 rounded p-2">
-                    <div className="flex items-center justify-between">
-                      <span>최근 평가:</span>
-                      <span>{alert.lastEvaluation}</span>
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-            
-            {/* 페이지네이션 */}
-            {totalPages > 1 && (
-              <div className="flex items-center justify-between mt-4 pt-4 border-t border-gray-200">
-                <button
-                  onClick={handlePrevPage}
-                  disabled={riskAlertPage === 0}
-                  className={`flex items-center gap-2 px-3 py-1 rounded-lg text-sm ${
-                    riskAlertPage === 0
-                      ? 'text-gray-400 cursor-not-allowed'
-                      : 'text-gray-700 hover:bg-gray-100'
-                  }`}
-                >
-                  <ChevronLeft className="h-4 w-4" />
-                  이전
-                </button>
-                
-                <span className="text-sm text-gray-600">
-                  {riskAlertPage + 1} / {totalPages}
-                </span>
-                
-                <button
-                  onClick={handleNextPage}
-                  disabled={riskAlertPage === totalPages - 1}
-                  className={`flex items-center gap-2 px-3 py-1 rounded-lg text-sm ${
-                    riskAlertPage === totalPages - 1
-                      ? 'text-gray-400 cursor-not-allowed'
-                      : 'text-gray-700 hover:bg-gray-100'
-                  }`}
-                >
-                  다음
-                  <ChevronRight className="h-4 w-4" />
-                </button>
-              </div>
-            )}
-          </div>
-
-          {/* 세 번째: 팀별 상담원 관리 */}
-          <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4 sm:p-6 flex flex-col h-full">
-            <h3 className="text-base sm:text-lg font-semibold text-gray-800 mb-4">팀별 상담원 관리</h3>
-            
-            {/* 팀 선택 드롭다운 */}
-            <div className="mb-4 sm:mb-6">
-              <label className="block text-sm font-medium text-gray-700 mb-2">팀 선택</label>
-              <div className="relative">
-                <button
-                  onClick={() => setIsTeamDropdownOpen(!isTeamDropdownOpen)}
-                  className="w-full flex items-center justify-between px-3 sm:px-4 py-2 sm:py-3 border border-gray-200 rounded-lg hover:border-pink-300 focus:outline-none focus:ring-2 focus:ring-pink-500 transition-colors"
-                >
-                  <span className="text-gray-900 truncate">{getSelectedTeamName()}</span>
-                  <ChevronDown className={`h-4 w-4 text-gray-500 transition-transform ${isTeamDropdownOpen ? 'rotate-180' : ''}`} />
-                </button>
-                
-                {isTeamDropdownOpen && (
-                  <div className="absolute top-full left-0 right-0 mt-1 bg-white border border-gray-200 rounded-lg shadow-lg z-10 max-h-60 overflow-y-auto">
-                    {teams.map((team) => (
+            {/* 검색 결과 */}
+            {showResults && (
+              <div className="mt-3 border-t border-gray-200 pt-3">
+                <h4 className="text-xs font-medium text-gray-700 mb-2">
+                  검색 결과 ({searchResults.length}개)
+                </h4>
+                {searchResults.length > 0 ? (
+                  <div className="space-y-2">
+                    {searchResults.slice(0, 4).map((result, index) => (
                       <div
-                        key={team.id}
-                        onClick={() => handleTeamSelect(team.id)}
-                        className="px-3 sm:px-4 py-2 sm:py-3 hover:bg-pink-50 cursor-pointer border-b border-gray-100 last:border-b-0"
+                        key={index}
+                        onClick={() =>
+                          result.type === "consultant" &&
+                          handleConsultantClick(result)
+                        }
+                        className="flex items-center gap-2 p-2 rounded-lg hover:bg-gray-50 transition-colors cursor-pointer"
                       >
-                        <div className="flex items-center justify-between">
-                          <div className="flex-1 min-w-0">
-                            <span className="font-medium text-gray-900 truncate block">{team.name}</span>
-                            <p className="text-sm text-gray-600 truncate">{team.teamLead}</p>
+                        {getTypeIcon(result.type)}
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-2">
+                            <span className="font-medium text-gray-900 truncate text-sm">
+                              {result.title}
+                            </span>
+                            <span className="px-1.5 py-0.5 bg-gray-100 text-gray-600 text-xs rounded-full whitespace-nowrap">
+                              {getTypeName(result.type)}
+                            </span>
                           </div>
-                          <span className="text-xs text-gray-500 whitespace-nowrap ml-2">{team.memberCount}명</span>
+                          <p className="text-xs text-gray-500 truncate">
+                            {result.subtitle}
+                          </p>
                         </div>
                       </div>
                     ))}
                   </div>
+                ) : (
+                  <p className="text-gray-500 text-center py-2 text-xs">
+                    검색 결과가 없습니다.
+                  </p>
                 )}
               </div>
-            </div>
+            )}
+          </div>
 
-            {/* 선택된 팀의 상담원 목록 */}
-            {selectedTeam && (
-              <div className="space-y-3 flex-1 overflow-y-auto">
-                <h4 className="text-sm sm:text-base font-semibold text-gray-800">
-                  {getSelectedTeamName()} 상담원 목록 ({getCurrentTeamMembers().length}명)
-                </h4>
-                <div className="space-y-3">
-                  {getCurrentTeamMembers().map((member) => (
-                    <div
-                      key={member.id}
-                      onClick={() => handleConsultantClick(member)}
-                      className="p-3 border border-gray-200 rounded-lg hover:shadow-md transition-all cursor-pointer hover:border-pink-300"
-                    >
-                      <div className="flex items-center justify-between mb-2">
-                        <h5 className="font-semibold text-gray-900 truncate">{member.name}</h5>
-                        <span className={`px-2 py-1 rounded-full text-xs font-medium whitespace-nowrap ${getStatusColor(member.status)}`}>
-                          {member.status}
+          {/* 3열 레이아웃 - 완전 반응형 */}
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-3">
+            {/* 첫 번째: 점검 추천 상담사 */}
+            <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4 flex flex-col h-[calc(100vh-17rem)]">
+              <div className="flex items-center gap-2 mb-3">
+                <Clock className="h-4 w-4 text-blue-500 flex-shrink-0" />
+                <h3 className="text-sm mt-0.5 font-semibold text-gray-800">
+                  점검 추천 상담사
+                </h3>
+                <span className="bg-blue-100 text-blue-800 text-xs font-medium px-1.5 py-0.5 rounded-full">
+                  {inspectionRecommendations.length}건
+                </span>
+              </div>
+
+              <div className="space-y-3 overflow-y-auto flex-1">
+                {paginatedInspectionRecommendations.map((recommendation) => (
+                  <div
+                    key={recommendation.id}
+                    onClick={() =>
+                      handleInspectionRecommendationClick(recommendation)
+                    }
+                    className="border border-blue-200 rounded-lg p-3 hover:bg-blue-50 transition-colors cursor-pointer"
+                  >
+                    <div className="flex items-start justify-between mb-2">
+                      <div className="flex-1 min-w-0">
+                        <h4 className="font-semibold text-gray-900 truncate text-sm">
+                          {recommendation.name}
+                        </h4>
+                        <p className="text-xs text-gray-600 truncate">
+                          {recommendation.team} - {recommendation.position}
+                        </p>
+                      </div>
+                      <span
+                        className={`px-1.5 py-0.5 text-xs font-medium rounded-full whitespace-nowrap ml-2 ${getPriorityColor(
+                          recommendation.priority
+                        )}`}
+                      >
+                        {getPriorityText(recommendation.priority)}
+                      </span>
+                    </div>
+
+                    <div className="space-y-1 mb-2">
+                      <div className="flex items-center justify-between text-xs">
+                        <span className="text-gray-600">마지막 점검</span>
+                        <span className="text-gray-800">
+                          {recommendation.lastInspection}
                         </span>
                       </div>
-                      <p className="text-sm text-gray-600 mb-2 truncate">{member.position}</p>
-                      <div className="flex justify-between text-sm">
-                        <span className="text-gray-500 truncate">오늘 통화: {member.callsToday}건</span>
-                        <span className="text-gray-500 whitespace-nowrap">⭐ {member.satisfactionScore}</span>
+                      <div className="flex items-center justify-between text-xs">
+                        <span className="text-gray-600">경과 일수</span>
+                        <span
+                          className={`font-medium ${
+                            calculateDaysDiff(recommendation.lastInspection) >
+                            30
+                              ? "text-red-600"
+                              : "text-gray-800"
+                          }`}
+                        >
+                          {calculateDaysDiff(recommendation.lastInspection)}일
+                        </span>
+                      </div>
+                      <div className="flex items-center justify-between text-xs">
+                        <span className="text-gray-600">담당 QC</span>
+                        <span className="text-gray-800 truncate">
+                          {recommendation.qcManager}
+                        </span>
                       </div>
                     </div>
-                  ))}
+
+                    <div className="text-xs text-gray-600 bg-gray-50 rounded p-1.5">
+                      {recommendation.recommendationReason}
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              {/* 페이지네이션 */}
+              {inspectionTotalPages > 1 && (
+                <div className="flex items-center justify-between mt-3 pt-3 border-t border-gray-200">
+                  <button
+                    onClick={handleInspectionPrevPage}
+                    disabled={inspectionPage === 0}
+                    className={`flex items-center gap-1 px-2 py-1 rounded-lg text-xs ${
+                      inspectionPage === 0
+                        ? "text-gray-400 cursor-not-allowed"
+                        : "text-gray-700 hover:bg-gray-100"
+                    }`}
+                  >
+                    <ChevronLeft className="h-3 w-3" />
+                    이전
+                  </button>
+
+                  <span className="text-xs text-gray-600">
+                    {inspectionPage + 1} / {inspectionTotalPages}
+                  </span>
+
+                  <button
+                    onClick={handleInspectionNextPage}
+                    disabled={inspectionPage === inspectionTotalPages - 1}
+                    className={`flex items-center gap-1 px-2 py-1 rounded-lg text-xs ${
+                      inspectionPage === inspectionTotalPages - 1
+                        ? "text-gray-400 cursor-not-allowed"
+                        : "text-gray-700 hover:bg-gray-100"
+                    }`}
+                  >
+                    다음
+                    <ChevronRight className="h-3 w-3" />
+                  </button>
+                </div>
+              )}
+            </div>
+
+            {/* 두 번째: 위험 등급 알림 (페이지네이션 적용) */}
+            <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4 flex flex-col h-[calc(100vh-17rem)]">
+              <div className="flex items-center gap-2 mb-3">
+                <AlertTriangle className="h-4 w-4 text-red-500 flex-shrink-0" />
+                <h3 className="text-sm mt-0.5 font-semibold text-gray-800">
+                  위험 등급 알림
+                </h3>
+                <span className="bg-red-100 text-red-800 text-xs font-medium px-1.5 py-0.5 rounded-full">
+                  {riskAlerts.length}건
+                </span>
+              </div>
+
+              <div className="space-y-3 flex-1 overflow-y-auto">
+                {paginatedRiskAlerts.map((alert) => (
+                  <div
+                    key={alert.id}
+                    onClick={() => handleRiskAlertClick(alert)}
+                    className="border border-red-200 rounded-lg p-3 hover:bg-red-50 transition-colors cursor-pointer"
+                  >
+                    <div className="flex items-start justify-between mb-2">
+                      <div className="flex-1 min-w-0">
+                        <h4 className="font-semibold text-gray-900 truncate text-sm">
+                          {alert.name}
+                        </h4>
+                        <p className="text-xs text-gray-600 truncate">
+                          {alert.team} - {alert.position}
+                        </p>
+                      </div>
+                      <div className="flex items-center gap-1 ml-2">
+                        {getSeverityIcon(alert.riskCategories[0].severity)}
+                        <span className="text-xs text-gray-500 whitespace-nowrap">
+                          긴급
+                        </span>
+                      </div>
+                    </div>
+
+                    <div className="space-y-1 mb-2">
+                      {alert.riskCategories.map((risk, index) => (
+                        <div
+                          key={index}
+                          className="flex items-center justify-between"
+                        >
+                          <span className="text-xs text-gray-700 truncate">
+                            {risk.category}
+                          </span>
+                          <span
+                            className={`px-1.5 py-0.5 text-xs font-bold rounded whitespace-nowrap min-w-[24px] text-center ${getGradeColor(
+                              risk.grade,
+                              risk.severity
+                            )}`}
+                          >
+                            {risk.grade}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+
+                    <div className="text-xs text-gray-600 bg-gray-50 rounded p-1.5">
+                      <div className="flex items-center justify-between">
+                        <span>최근 평가:</span>
+                        <span>{alert.lastEvaluation}</span>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+
+              {/* 페이지네이션 */}
+              {totalPages > 1 && (
+                <div className="flex items-center justify-between mt-3 pt-3 border-t border-gray-200">
+                  <button
+                    onClick={handlePrevPage}
+                    disabled={riskAlertPage === 0}
+                    className={`flex items-center gap-1 px-2 py-1 rounded-lg text-xs ${
+                      riskAlertPage === 0
+                        ? "text-gray-400 cursor-not-allowed"
+                        : "text-gray-700 hover:bg-gray-100"
+                    }`}
+                  >
+                    <ChevronLeft className="h-3 w-3" />
+                    이전
+                  </button>
+
+                  <span className="text-xs text-gray-600">
+                    {riskAlertPage + 1} / {totalPages}
+                  </span>
+
+                  <button
+                    onClick={handleNextPage}
+                    disabled={riskAlertPage === totalPages - 1}
+                    className={`flex items-center gap-1 px-2 py-1 rounded-lg text-xs ${
+                      riskAlertPage === totalPages - 1
+                        ? "text-gray-400 cursor-not-allowed"
+                        : "text-gray-700 hover:bg-gray-100"
+                    }`}
+                  >
+                    다음
+                    <ChevronRight className="h-3 w-3" />
+                  </button>
+                </div>
+              )}
+            </div>
+
+            {/* 세 번째: 팀별 상담원 관리 */}
+            <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4 flex flex-col h-[calc(100vh-17rem)]">
+              <div className="flex items-center gap-2 mb-3">
+                <Users className="h-4 w-4 text-purple-500 flex-shrink-0" />
+                <h3 className="text-sm mt-0.5 font-semibold text-gray-800">
+                  팀별 상담원 관리
+                </h3>
+              </div>
+
+              {/* 팀 선택 드롭다운 */}
+              <div className="mb-3">
+                <label className="block text-xs font-medium text-gray-700 mb-2">
+                  팀 선택
+                </label>
+                <div className="relative">
+                  <button
+                    onClick={() => setIsTeamDropdownOpen(!isTeamDropdownOpen)}
+                    className="w-full flex items-center justify-between px-3 py-2 border border-gray-200 rounded-lg hover:border-pink-300 focus:outline-none focus:ring-2 focus:ring-pink-500 transition-colors"
+                  >
+                    <span className="text-gray-900 truncate">
+                      {getSelectedTeamName()}
+                    </span>
+                    <ChevronDown
+                      className={`h-4 w-4 text-gray-500 transition-transform ${
+                        isTeamDropdownOpen ? "rotate-180" : ""
+                      }`}
+                    />
+                  </button>
+
+                  {isTeamDropdownOpen && (
+                    <div className="absolute top-full left-0 right-0 mt-1 bg-white border border-gray-200 rounded-lg shadow-lg z-10 max-h-60 overflow-y-auto">
+                      {teams.map((team) => (
+                        <div
+                          key={team.id}
+                          onClick={() => handleTeamSelect(team.id)}
+                          className="px-3 sm:px-4 py-2 sm:py-3 hover:bg-pink-50 cursor-pointer border-b border-gray-100 last:border-b-0"
+                        >
+                          <div className="flex items-center justify-between">
+                            <div className="flex-1 min-w-0">
+                              <span className="font-medium text-gray-900 truncate block text-sm">
+                                {team.name}
+                              </span>
+                              <p className="text-xs text-gray-600 truncate">
+                                {team.teamLead}
+                              </p>
+                            </div>
+                            <span className="text-xs text-gray-500 whitespace-nowrap ml-2">
+                              {team.memberCount}명
+                            </span>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
                 </div>
               </div>
-            )}
-            
-            {!selectedTeam && (
-              <div className="text-center py-8 text-gray-500 flex-1 flex flex-col items-center justify-center">
-                <Users className="h-12 w-12 mx-auto mb-3 text-gray-400" />
-                <p className="text-sm sm:text-base">팀을 선택하여 상담원 목록을 확인하세요</p>
-              </div>
-            )}
+
+              {/* 선택된 팀의 상담원 목록 */}
+              {selectedTeam && (
+                <div className="flex flex-col flex-1">
+                  <h4 className="text-sm font-semibold text-gray-800 mb-2">
+                    {getSelectedTeamName()} 상담원 목록 (
+                    {getCurrentTeamMembers().length}명)
+                  </h4>
+                  <div className="space-y-3 flex-1 overflow-y-auto">
+                    {paginatedTeamMembers.map((member) => (
+                      <div
+                        key={member.id}
+                        onClick={() => handleConsultantClick(member)}
+                        className="p-3 border border-gray-200 rounded-lg hover:shadow-md transition-all cursor-pointer hover:border-pink-300"
+                      >
+                        <div className="flex items-center justify-between mb-1">
+                          <h5 className="font-semibold text-gray-900 truncate text-sm">
+                            {member.name}
+                          </h5>
+                        </div>
+                        <p className="text-xs text-gray-600 mb-1 truncate">
+                          {member.position}
+                        </p>
+                        <div className="flex justify-between text-xs">
+                          <span className="text-gray-500 truncate">
+                            오늘 통화: {member.callsToday}건
+                          </span>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+
+                  {/* 팀별 상담원 페이지네이션 */}
+                  {teamTotalPages > 1 && (
+                    <div className="flex items-center justify-between mt-3 pt-3 border-t border-gray-200">
+                      <button
+                        onClick={handleTeamPrevPage}
+                        disabled={teamMemberPage === 0}
+                        className={`flex items-center gap-1 px-2 py-1 rounded-lg text-xs ${
+                          teamMemberPage === 0
+                            ? "text-gray-400 cursor-not-allowed"
+                            : "text-gray-700 hover:bg-gray-100"
+                        }`}
+                      >
+                        <ChevronLeft className="h-3 w-3" />
+                        이전
+                      </button>
+
+                      <span className="text-xs text-gray-600">
+                        {teamMemberPage + 1} / {teamTotalPages}
+                      </span>
+
+                      <button
+                        onClick={handleTeamNextPage}
+                        disabled={teamMemberPage === teamTotalPages - 1}
+                        className={`flex items-center gap-1 px-2 py-1 rounded-lg text-xs ${
+                          teamMemberPage === teamTotalPages - 1
+                            ? "text-gray-400 cursor-not-allowed"
+                            : "text-gray-700 hover:bg-gray-100"
+                        }`}
+                      >
+                        다음
+                        <ChevronRight className="h-3 w-3" />
+                      </button>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {!selectedTeam && (
+                <div className="text-center py-6 text-gray-500 flex-1 flex flex-col items-center justify-center">
+                  <Users className="h-8 w-8 mx-auto mb-2 text-gray-400" />
+                  <p className="text-sm">
+                    팀을 선택하여 상담원 목록을 확인하세요
+                  </p>
+                </div>
+              )}
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -32,7 +32,7 @@ export default function Header({
               height={22}
               className="h-6 w-auto flex-shrink-0"
             />
-            <span className="text-2xl mb-2 font-bold text-white korean-heading header-white-text leading-none">
+            <span className="text-[22px] mb-1 font-bold text-white korean-heading header-white-text leading-none">
               Feple
             </span>
           </Link>

--- a/src/data/qcData.ts
+++ b/src/data/qcData.ts
@@ -1,0 +1,214 @@
+// QC 대시보드 더미 데이터
+
+// 검색 데이터
+export const searchData = [
+  {
+    type: "consultant",
+    title: "김민수",
+    subtitle: "고객상담 1팀 - 선임 상담사",
+    link: "/consultants",
+  },
+  {
+    type: "consultant",
+    title: "이영희",
+    subtitle: "고객상담 2팀 - 상담사",
+    link: "/consultants",
+  },
+  {
+    type: "consultant",
+    title: "박성호",
+    subtitle: "고객상담 1팀 - 상담사",
+    link: "/consultants",
+  },
+  {
+    type: "consultant",
+    title: "최미연",
+    subtitle: "고객상담 3팀 - 팀장",
+    link: "/consultants",
+  },
+  {
+    type: "consultant",
+    title: "노준석",
+    subtitle: "고객상담 1팀 - 상담사",
+    link: "/consultants",
+  },
+];
+
+// 팀 데이터
+export const teams = [
+  { id: "team1", name: "고객상담 1팀", memberCount: 12, teamLead: "김팀장" },
+  { id: "team2", name: "고객상담 2팀", memberCount: 15, teamLead: "이팀장" },
+  { id: "team3", name: "고객상담 3팀", memberCount: 10, teamLead: "박팀장" },
+  { id: "team4", name: "기술지원팀", memberCount: 8, teamLead: "최팀장" },
+];
+
+// 팀별 상담원 데이터
+export const teamMembers = {
+  team1: [
+    {
+      id: "c1",
+      name: "김민수",
+      position: "선임 상담사",
+      callsToday: 23,
+    },
+    {
+      id: "c2",
+      name: "박성호",
+      position: "상담사",
+      callsToday: 18,
+    },
+    {
+      id: "c3",
+      name: "임지원",
+      position: "상담사",
+      callsToday: 15,
+    },
+    {
+      id: "c12",
+      name: "노준석",
+      position: "상담사",
+      callsToday: 12,
+    },
+  ],
+  team2: [
+    {
+      id: "c4",
+      name: "이영희",
+      position: "상담사",
+      callsToday: 20,
+    },
+    {
+      id: "c5",
+      name: "정다은",
+      position: "상담사",
+      callsToday: 16,
+    },
+    {
+      id: "c6",
+      name: "강현준",
+      position: "선임 상담사",
+      callsToday: 25,
+    },
+  ],
+  team3: [
+    {
+      id: "c7",
+      name: "최미연",
+      position: "팀장",
+      callsToday: 12,
+    },
+    {
+      id: "c8",
+      name: "한상욱",
+      position: "상담사",
+      callsToday: 19,
+    },
+    {
+      id: "c9",
+      name: "송예진",
+      position: "상담사",
+      callsToday: 14,
+    },
+  ],
+  team4: [
+    {
+      id: "c10",
+      name: "윤진호",
+      position: "기술지원",
+      callsToday: 8,
+    },
+    {
+      id: "c11",
+      name: "조은실",
+      position: "기술지원",
+      callsToday: 10,
+    },
+  ],
+};
+
+// 점검 추천 상담사 데이터
+export const inspectionRecommendations = [
+  {
+    id: "c15",
+    name: "문지호",
+    team: "고객상담 1팀",
+    position: "상담사",
+    lastInspection: "2025-06-09",
+    daysSinceInspection: 38,
+    recommendationReason: "정기 점검 주기 초과",
+    priority: "high",
+    qcManager: "김QC",
+  },
+  {
+    id: "c16",
+    name: "서민정",
+    team: "고객상담 2팀",
+    position: "선임 상담사",
+    lastInspection: "2025-06-25",
+    daysSinceInspection: 22,
+    recommendationReason: "성과 개선 모니터링",
+    priority: "medium",
+    qcManager: "이QC",
+  },
+  {
+    id: "c17",
+    name: "조현우",
+    team: "기술지원팀",
+    position: "기술지원",
+    lastInspection: "2025-05-22",
+    daysSinceInspection: 56,
+    recommendationReason: "장기 미점검",
+    priority: "high",
+    qcManager: "박QC",
+  },
+  {
+    id: "c18",
+    name: "배수진",
+    team: "고객상담 3팀",
+    position: "상담사",
+    lastInspection: "2025-07-04",
+    daysSinceInspection: 13,
+    recommendationReason: "신규 교육 후 점검",
+    priority: "low",
+    qcManager: "최QC",
+  },
+];
+
+// 위험 등급 상담사 데이터
+export const riskAlerts = [
+  {
+    id: "c12",
+    name: "노준석",
+    team: "고객상담 1팀",
+    position: "상담사",
+    riskCategories: [
+      { category: "공감적 소통", grade: "F", severity: "warning" },
+      { category: "정중함", grade: "G", severity: "critical" },
+    ],
+    lastEvaluation: "2025-07-17 14:30",
+    actionRequired: true,
+  },
+  {
+    id: "c13",
+    name: "김철호",
+    team: "고객상담 2팀",
+    position: "상담사",
+    riskCategories: [
+      { category: "문제 해결", grade: "F", severity: "warning" },
+    ],
+    lastEvaluation: "2025-07-16 13:15",
+    actionRequired: true,
+  },
+  {
+    id: "c14",
+    name: "이수정",
+    team: "기술지원팀",
+    position: "기술지원",
+    riskCategories: [
+      { category: "감정 안정성", grade: "G", severity: "critical" },
+      { category: "대화 흐름", grade: "F", severity: "warning" },
+    ],
+    lastEvaluation: "2025-07-17 12:45",
+    actionRequired: true,
+  },
+];


### PR DESCRIPTION
## 💡 개선 사항

QC 대시보드의 전반적인 UI/UX를 개선하여 사용성과 가독성을 향상시켰습니다.

### 1. 레이아웃 최적화
- 각 섹션(점검 추천/위험 등급/팀별 관리)의 높이를 `calc(100vh-17rem)`로 통일
- 섹션 간 간격 및 여백 조정으로 시각적 일관성 확보
- 아이콘과 제목의 수직 정렬 개선 (`mt-0.5` 적용)

### 2. 위험 등급 표시 개선
- G등급을 critical(빨간색), F등급을 warning(주황색)으로 변경
- 위험 등급에 깜빡임 효과 추가 (`animate-pulse`)
- 등급 표시 크기 통일 (`min-w-[24px]`, `text-center`)

### 3. 기능 개선
- 팀별 상담원 관리에 페이지네이션 추가 (2명/페이지)
- 불필요한 상담원 상태 정보 제거로 UI 간소화
- 각 섹션의 스크롤 영역 최적화