### PR TITLE
feat: QC 대시보드 UI/UX 개선 및 상담사 페이지 날짜 관리 로직 개선

### DIFF
--- a/src/app/consultant/page.tsx
+++ b/src/app/consultant/page.tsx
@@ -5,25 +5,21 @@ import { useRouter } from "next/navigation";
 import DashboardLayout from "@/components/DashboardLayout";
 import { RadarChart } from "@/components/charts/RadarChart";
 import { ChevronRight } from "lucide-react";
+import { useDateRange } from "@/context/DateRangeContext";
 
 export default function ConsultantDashboardPage() {
   const router = useRouter();
+  const { setDateRange } = useDateRange();
 
   // 기간 선택 상태
   const [selectedPeriod, setSelectedPeriod] = useState<
     "yesterday" | "lastWeek" | "lastMonth"
   >("yesterday");
 
-  // 날짜 계산 함수들 (한국 시간 기준)
+  // 날짜 계산 함수들 (한국 시간 기준) - 테스트용 고정 날짜
   const getDateRange = (period: "yesterday" | "lastWeek" | "lastMonth") => {
-    // 한국 시간 기준으로 현재 날짜 계산
-    const now = new Date();
-    const koreaTime = new Date(now.getTime() + 9 * 60 * 60 * 1000); // UTC+9
-    const today = new Date(
-      koreaTime.getFullYear(),
-      koreaTime.getMonth(),
-      koreaTime.getDate()
-    );
+    // 테스트를 위해 고정된 오늘 날짜 사용 (2025-07-17)
+    const today = new Date("2025-07-17");
 
     const formatDate = (date: Date) => {
       const year = date.getFullYear();
@@ -84,9 +80,12 @@ export default function ConsultantDashboardPage() {
   // 상세 보기 페이지로 이동
   const handleDetailView = () => {
     const { startDate, endDate } = getDateRange(selectedPeriod);
-    router.push(
-      `/consultant/performance?startDate=${startDate}&endDate=${endDate}`
-    );
+
+    // 전역 날짜 상태 업데이트
+    setDateRange(startDate, endDate);
+
+    // 페이지 이동
+    router.push(`/consultant/performance`);
   };
 
   // 기간별 데이터

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next";
 import "@/styles/index.css";
 import { AnalysisResultProvider } from "@/context/AnalysisResultContext";
 import { SidebarProvider } from "@/context/SidebarContext";
+import { DateRangeProvider } from "@/context/DateRangeContext";
 
 export const metadata: Metadata = {
   title: "Feple Dashboard",
@@ -23,7 +24,9 @@ export default function RootLayout({
     <html lang="ko">
       <body className="bg-white font-sans antialiased text-sm">
         <SidebarProvider>
-          <AnalysisResultProvider>{children}</AnalysisResultProvider>
+          <DateRangeProvider>
+            <AnalysisResultProvider>{children}</AnalysisResultProvider>
+          </DateRangeProvider>
         </SidebarProvider>
       </body>
     </html>

--- a/src/app/qc/page.tsx
+++ b/src/app/qc/page.tsx
@@ -29,11 +29,11 @@ export default function QCDashboardPage() {
   const [teamMemberPage, setTeamMemberPage] = useState(0);
 
   // QC 정보
-  const qcName = "김민준";
+  const qcName = "점소이현서";
   const qcInitial = qcName[0];
 
-  // 오늘 날짜 (2025-07-17)
-  const today = new Date("2025-07-17");
+  // 오늘 날짜
+  const today = new Date(Date.now());
 
   // 경과 일수 계산 함수
   const calculateDaysDiff = (dateString: string): number => {

--- a/src/context/DateRangeContext.tsx
+++ b/src/context/DateRangeContext.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import React, { createContext, useContext, useState, useEffect } from "react";
+
+interface DateRangeContextType {
+  startDate: string;
+  endDate: string;
+  setDateRange: (startDate: string, endDate: string) => void;
+  resetToYesterday: () => void;
+}
+
+const DateRangeContext = createContext<DateRangeContextType | undefined>(
+  undefined
+);
+
+// 어제 날짜 계산 함수 (한국 시간 기준) - 테스트용 고정 날짜
+const getYesterdayDate = () => {
+  // 테스트를 위해 고정된 오늘 날짜 사용 (2025-07-17)
+  const today = new Date("2025-07-17");
+
+  const yesterday = new Date(today);
+  yesterday.setDate(today.getDate() - 1);
+
+  const year = yesterday.getFullYear();
+  const month = String(yesterday.getMonth() + 1).padStart(2, "0");
+  const day = String(yesterday.getDate()).padStart(2, "0");
+
+  return `${year}-${month}-${day}`;
+};
+
+export function DateRangeProvider({ children }: { children: React.ReactNode }) {
+  const [startDate, setStartDate] = useState<string>("");
+  const [endDate, setEndDate] = useState<string>("");
+
+  // 초기값 설정 (어제 날짜)
+  useEffect(() => {
+    const yesterday = getYesterdayDate();
+    setStartDate(yesterday);
+    setEndDate(yesterday);
+  }, []);
+
+  const setDateRange = (newStartDate: string, newEndDate: string) => {
+    setStartDate(newStartDate);
+    setEndDate(newEndDate);
+  };
+
+  const resetToYesterday = () => {
+    const yesterday = getYesterdayDate();
+    setStartDate(yesterday);
+    setEndDate(yesterday);
+  };
+
+  return (
+    <DateRangeContext.Provider
+      value={{
+        startDate,
+        endDate,
+        setDateRange,
+        resetToYesterday,
+      }}
+    >
+      {children}
+    </DateRangeContext.Provider>
+  );
+}
+
+export function useDateRange() {
+  const context = useContext(DateRangeContext);
+  if (context === undefined) {
+    throw new Error("useDateRange must be used within a DateRangeProvider");
+  }
+  return context;
+}


### PR DESCRIPTION
## 💡 주요 개선 사항

이번 PR에서는 QC 대시보드의 UI/UX를 개선하고, 상담사 페이지의 날짜 관리 로직을 전면 개선했습니다.

### 1. QC 대시보드 UI/UX 개선

#### 1.1 레이아웃 및 디자인
- 각 섹션 높이를 `calc(100vh-17rem)`로 최적화하여 일관된 레이아웃 구현
- 섹션 간 간격 및 여백 조정으로 시각적 일관성 확보
- 아이콘과 제목의 수직 정렬 개선 (`mt-0.5`, `flex-shrink-0` 적용)

#### 1.2 위험 등급 표시 개선
- G등급을 critical(빨간색), F등급을 warning(주황색)으로 변경
- 위험 등급에 깜빡임 효과 추가 (`animate-pulse`)
- 등급 표시 크기 통일 (`min-w-[24px]`, `text-center`)

#### 1.3 기능 개선
- 팀별 상담원 관리에 페이지네이션 추가 (2명/페이지)
- 불필요한 상담원 상태 정보 제거로 UI 간소화
- 각 섹션의 스크롤 영역 최적화

### 2. 상담사 페이지 날짜 관리 개선

#### 2.1 전역 상태 관리 추가
- `DateRangeContext` 생성 및 구현
  - 날짜 범위 전역 상태 관리
  - 어제 날짜 자동 계산 (한국 시간 기준)
  - 날짜 범위 설정 및 초기화 기능

#### 2.2 날짜 계산 로직 개선
- 한국 시간 기준으로 정확한 날짜 계산
- 테스트를 위한 고정 날짜 설정 (2025-07-17)
- 전일/저번 주/저번 달 계산 로직 정확성 확보

#### 2.3 조회 기간 상태 관리
- 페이지 전환 시에도 조회 기간 유지
- 날짜 변경은 다음 두 경우에만 허용:
  1. 상담사 메인 페이지에서 상세 보기 클릭 시
  2. 상담사 성과 페이지에서 조회 버튼 클릭 시