### PR TITLE
feat: QC 모니터링 페이지 UI/UX 개선 및 자동 조회 기능 추가

### DIFF
--- a/src/app/qc/page.tsx
+++ b/src/app/qc/page.tsx
@@ -69,6 +69,59 @@ export default function QCDashboardPage() {
     return "기타";
   };
 
+  // 상담사 이름으로 부서 찾기
+  const findDepartmentByConsultantName = (consultantName: string): string => {
+    const departments = {
+      team1: ["김민수", "박성호", "임지원", "노준석", "문지호"],
+      team2: ["이영희", "정다은", "강현준", "서민정", "김철호"],
+      team3: ["최미연", "한상욱", "송예진", "배수진"],
+      team4: ["윤진호", "조은실", "조현우", "이수정"],
+    };
+
+    for (const [deptId, names] of Object.entries(departments)) {
+      if (names.includes(consultantName)) {
+        return deptId;
+      }
+    }
+    return "team1"; // 기본값
+  };
+
+  // 상담사 이름으로 ID 찾기
+  const findConsultantIdByName = (consultantName: string): string => {
+    const consultantMap: { [key: string]: string } = {
+      // 기존 팀 멤버들
+      김민수: "c1",
+      박성호: "c2",
+      임지원: "c3",
+      노준석: "c12",
+      이영희: "c4",
+      정다은: "c5",
+      강현준: "c6",
+      최미연: "c7",
+      한상욱: "c8",
+      송예진: "c9",
+      윤진호: "c10",
+      조은실: "c11",
+      // 점검 추천 상담사들
+      문지호: "c15",
+      서민정: "c16",
+      조현우: "c17",
+      배수진: "c18",
+      // 위험 등급 알림 상담사들
+      김철호: "c13",
+      이수정: "c14",
+    };
+
+    return consultantMap[consultantName] || "c1"; // 기본값
+  };
+
+  // 전일 날짜 계산
+  const getYesterdayDate = (): string => {
+    const yesterday = new Date(today);
+    yesterday.setDate(yesterday.getDate() - 1);
+    return yesterday.toISOString().split("T")[0];
+  };
+
   const handleConsultantClick = (
     consultant:
       | {
@@ -84,22 +137,39 @@ export default function QCDashboardPage() {
           link: string;
         }
   ) => {
-    // 상담 모니터링 페이지로 이동
+    const yesterdayDate = getYesterdayDate();
+
     if ("id" in consultant) {
-      window.location.href = `/performance?consultant=${consultant.id}`;
+      // 팀별 상담원의 경우
+      const departmentId = findDepartmentByConsultantName(consultant.name);
+      const consultantId = findConsultantIdByName(consultant.name);
+
+      window.location.href = `/qc/performance?startDate=${yesterdayDate}&endDate=${yesterdayDate}&department=${departmentId}&consultant=${consultantId}&autoSearch=true`;
     } else {
-      window.location.href = `/performance?consultant=${consultant.title}`;
+      // 검색 결과의 경우
+      const departmentId = findDepartmentByConsultantName(consultant.title);
+      const consultantId = findConsultantIdByName(consultant.title);
+
+      window.location.href = `/qc/performance?startDate=${yesterdayDate}&endDate=${yesterdayDate}&department=${departmentId}&consultant=${consultantId}&autoSearch=true`;
     }
   };
 
   const handleRiskAlertClick = (alert: (typeof riskAlerts)[0]) => {
-    window.location.href = `/performance?consultant=${alert.id}`;
+    const yesterdayDate = getYesterdayDate();
+    const departmentId = findDepartmentByConsultantName(alert.name);
+    const consultantId = findConsultantIdByName(alert.name);
+
+    window.location.href = `/qc/performance?startDate=${yesterdayDate}&endDate=${yesterdayDate}&department=${departmentId}&consultant=${consultantId}&autoSearch=true`;
   };
 
   const handleInspectionRecommendationClick = (
     recommendation: (typeof inspectionRecommendations)[0]
   ) => {
-    window.location.href = `/performance?consultant=${recommendation.id}`;
+    const yesterdayDate = getYesterdayDate();
+    const departmentId = findDepartmentByConsultantName(recommendation.name);
+    const consultantId = findConsultantIdByName(recommendation.name);
+
+    window.location.href = `/qc/performance?startDate=${yesterdayDate}&endDate=${yesterdayDate}&department=${departmentId}&consultant=${consultantId}&autoSearch=true`;
   };
 
   const getGradeColor = (grade: string, severity: string) => {

--- a/src/app/qc/performance/page.tsx
+++ b/src/app/qc/performance/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { useSearchParams } from "next/navigation";
 import DashboardLayout from "@/components/DashboardLayout";
 import { ChevronDown, PhoneCall } from "lucide-react";
 import {
@@ -13,6 +14,7 @@ import { ScoreChart } from "@/components/features/performance";
 import { useDateRange } from "@/context/DateRangeContext";
 
 export default function QCMonitoringPage() {
+  const searchParams = useSearchParams();
   const {
     startDate: contextStartDate,
     endDate: contextEndDate,
@@ -28,6 +30,47 @@ export default function QCMonitoringPage() {
     null
   );
   const [hasSearched, setHasSearched] = useState(false); // 조회 여부 상태
+
+  // URL 파라미터에서 자동 조회 처리
+  useEffect(() => {
+    const startDateParam = searchParams.get("startDate");
+    const endDateParam = searchParams.get("endDate");
+    const departmentParam = searchParams.get("department");
+    const consultantParam = searchParams.get("consultant");
+    const autoSearchParam = searchParams.get("autoSearch");
+
+    if (
+      autoSearchParam === "true" &&
+      startDateParam &&
+      endDateParam &&
+      departmentParam &&
+      consultantParam
+    ) {
+      // URL 파라미터로 상태 설정
+      setLocalStartDate(startDateParam);
+      setLocalEndDate(endDateParam);
+      setSelectedDepartment(departmentParam);
+      setSelectedConsultant(consultantParam);
+
+      // 컨텍스트 업데이트
+      setDateRange(startDateParam, endDateParam);
+
+      // 자동 조회 실행
+      setHasSearched(true);
+      setSelectedSessionNo(null);
+
+      console.log(
+        "자동 조회 실행:",
+        startDateParam,
+        "~",
+        endDateParam,
+        "부서",
+        departmentParam,
+        "상담원",
+        consultantParam
+      );
+    }
+  }, [searchParams, setDateRange]);
 
   // 부서 데이터
   const departments = [
@@ -165,7 +208,7 @@ export default function QCMonitoringPage() {
 
   return (
     <DashboardLayout>
-      <div className="w-full min-h-screen bg-gradient-to-br from-pink-50 via-purple-50 to-indigo-50 p-3">
+      <div className="min-h-screen w-full bg-gray-50 p-3">
         <div className="space-y-3">
           {/* 통합 조회 옵션 - 기간 + 부서 + 상담원 + 조회 버튼 */}
           <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-3">
@@ -239,10 +282,10 @@ export default function QCMonitoringPage() {
           {/* 메인 콘텐츠 - 조회 후에만 표시 */}
           {hasSearched && selectedConsultant && (
             <div
-              className="grid gap-3 h-[calc(100vh-10rem)]"
+              className="grid gap-3 h-full"
               style={{ gridTemplateColumns: "0.75fr 2.5fr 0.75fr" }}
             >
-              {/* 첫 번째 열 (0.7): 선택된 상담사 정보 + 점수 + 통화시간 */}
+              {/* 첫 번째 열 (0.75): 선택된 상담사 정보 + 점수 + 통화시간 */}
               <div className="space-y-3 h-full overflow-y-auto">
                 {/* 선택된 상담사 정보 */}
                 <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-3">
@@ -279,7 +322,7 @@ export default function QCMonitoringPage() {
                 />
               </div>
 
-              {/* 두 번째 열 (2.6): 상담 세션 목록 (ConsultationTable 컴포넌트 사용) */}
+              {/* 두 번째 열 (2.5): 상담 세션 목록 (ConsultationTable 컴포넌트 사용) */}
               <div className="h-full">
                 <ConsultationTable
                   startDate={contextStartDate}
@@ -289,7 +332,7 @@ export default function QCMonitoringPage() {
                 />
               </div>
 
-              {/* 세 번째 열 (0.7): 상세 분석 (ConversationDetail 컴포넌트 사용) */}
+              {/* 세 번째 열 (0.75): 상세 분석 (ConversationDetail 컴포넌트 사용) */}
               <div className="h-full">
                 <ConversationDetail
                   sessionNo={selectedSessionNo}


### PR DESCRIPTION
## 변경사항 요약
1. QC 성과 모니터링 페이지 UI 개선
   - 필터 영역 컴팩트화
   - 레이아웃 비율 최적화
   - 배경 스타일 통일

2. QC 대시보드 → 모니터링 페이지 자동 조회 기능 추가
   - 전일 데이터 자동 조회
   - 상담사별 부서/ID 자동 매핑
   - URL 파라미터 기반 자동 실행

## 상세 변경사항

### 1. QC 성과 모니터링 페이지 UI 개선
- **필터 영역 크기 최적화**
  - 텍스트 크기: `text-sm` → `text-xs`
  - 입력 필드 패딩: `px-3 py-2` → `px-2 py-1`
  - 아이콘 크기: `h-4 w-4` → `h-3 w-3`
  - 컨테이너 패딩: `p-4` → `p-3`
  - 요소 간 간격: `gap-4` → `gap-3`

- **레이아웃 비율 조정**
  - 그리드 비율: `0.75fr 2.5fr 0.75fr`
  - 테이블에 더 많은 공간 할당
  - 높이 설정 최적화: `h-full`

- **드롭다운 화살표 개선**
  - `appearance-none` 적용으로 기본 화살표 숨김
  - 커스텀 화살표 크기 및 위치 조정

### 2. 자동 조회 기능 추가
- **URL 파라미터 기반 자동 조회**
  ```typescript
  /qc/performance?startDate=2025-07-16&endDate=2025-07-16&department=team1&consultant=c15&autoSearch=true
  ```

- **상담사 정보 자동 매핑**
  - 기존 팀 멤버 (12명)
  - 점검 추천 상담사 (4명)
  - 위험 등급 알림 상담사 (2명)

- **자동 조회 지원 컴포넌트**
  - 점검 추천 상담사 카드
  - 위험 등급 알림 카드
  - 팀별 상담원 관리 카드
  - 검색 결과 상담사

### 3. 세션 번호 2000 에러 해결
- 2000번대 세션 번호 처리 로직 추가
- 기본 데이터 순환 처리로 안정성 확보