### PR TITLE
feat: 사용자 정보 관리 기능 추가 및 로그인 페이지 개선

### DIFF
--- a/src/app/consultant/page.tsx
+++ b/src/app/consultant/page.tsx
@@ -1,25 +1,36 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import DashboardLayout from "@/components/DashboardLayout";
 import { RadarChart } from "@/components/charts/RadarChart";
 import { ChevronRight } from "lucide-react";
 import { useDateRange } from "@/context/DateRangeContext";
+import { useUser } from "@/context/UserContext";
 
 export default function ConsultantDashboardPage() {
   const router = useRouter();
   const { setDateRange } = useDateRange();
+  const { setUserInfo } = useUser();
+
+  // 상담사 정보 (이름, 이니셜)
+  const userName = "마교준석";
+  const userInitial = userName[0];
+
+  // UserContext에 사용자 정보 설정
+  useEffect(() => {
+    setUserInfo({ name: `${userName} 상담사`, initial: userInitial });
+  }, [setUserInfo, userName, userInitial]);
 
   // 기간 선택 상태
   const [selectedPeriod, setSelectedPeriod] = useState<
     "yesterday" | "lastWeek" | "lastMonth"
   >("yesterday");
 
-  // 날짜 계산 함수들 (한국 시간 기준) - 테스트용 고정 날짜
+  // 날짜 계산 함수들 (한국 시간 기준)
   const getDateRange = (period: "yesterday" | "lastWeek" | "lastMonth") => {
-    // 테스트를 위해 고정된 오늘 날짜 사용 (2025-07-17)
-    const today = new Date("2025-07-17");
+    // 테스트를 위해 고정된 오늘 날짜 사용
+    const today = new Date(Date.now());
 
     const formatDate = (date: Date) => {
       const year = date.getFullYear();
@@ -185,10 +196,6 @@ export default function ConsultantDashboardPage() {
   const lowIndicators = [...currentData.indicators]
     .sort((a, b) => a.score - b.score)
     .slice(0, 2);
-
-  // 상담사 정보 (이니셜, 이름)
-  const userName = "마교준석";
-  const userInitial = userName[0];
 
   // 기간 변경 핸들러
   const handlePeriodChange = (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import "@/styles/index.css";
 import { AnalysisResultProvider } from "@/context/AnalysisResultContext";
 import { SidebarProvider } from "@/context/SidebarContext";
 import { DateRangeProvider } from "@/context/DateRangeContext";
+import { UserProvider } from "@/context/UserContext";
 
 export const metadata: Metadata = {
   title: "Feple Dashboard",
@@ -23,11 +24,13 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body className="bg-white font-sans antialiased text-sm">
-        <SidebarProvider>
-          <DateRangeProvider>
-            <AnalysisResultProvider>{children}</AnalysisResultProvider>
-          </DateRangeProvider>
-        </SidebarProvider>
+        <UserProvider>
+          <SidebarProvider>
+            <DateRangeProvider>
+              <AnalysisResultProvider>{children}</AnalysisResultProvider>
+            </DateRangeProvider>
+          </SidebarProvider>
+        </UserProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,187 +1,206 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "next/navigation";
-import { Users, Shield, ArrowRight, UserCheck, Settings } from "lucide-react";
+import { supabase } from "@/lib/supabaseClient";
+import {
+  Users,
+  Shield,
+  ArrowRight,
+  Mail,
+  Settings,
+  Loader2,
+} from "lucide-react";
 
-export default function RoleSelectionPage() {
-  const [selectedRole, setSelectedRole] = useState<string | null>(null);
-  const router = useRouter();
+export default function LoginPage() {
+  const [role, setRole] = useState<"consultant" | "qc" | null>(null);
+  const [email, setEmail] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-  const handleRoleSelect = (role: string) => {
-    setSelectedRole(role);
-  };
+  const handleLogin = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
 
-  const handleContinue = () => {
-    if (selectedRole === "consultant") {
-      router.push("/consultant");
-    } else if (selectedRole === "qc") {
-      router.push("/qc");
+    if (!role) {
+      setError("역할이 선택되지 않았습니다.");
+      setLoading(false);
+      return;
+    }
+
+    // 프로덕션 환경을 고려하여 window.location.origin 사용
+    const redirectUrl = `${window.location.origin}/${role}`;
+
+    try {
+      const { error } = await supabase.auth.signInWithOtp({
+        email,
+        options: {
+          emailRedirectTo: redirectUrl,
+        },
+      });
+
+      if (error) throw error;
+
+      setSubmitted(true);
+    } catch (err: unknown) {
+      let errorMessage = "로그인 링크 전송 중 알 수 없는 오류가 발생했습니다.";
+      if (err instanceof Error) {
+        errorMessage = err.message;
+      }
+      setError(errorMessage);
+    } finally {
+      setLoading(false);
     }
   };
 
-  return (
-    <div className="bg-gradient-to-br from-pink-50 via-purple-50 to-indigo-50 min-h-screen flex items-center justify-center">
-      <div className="container mx-auto px-4 py-6 max-w-4xl">
-        <div className="space-y-6">
-          {/* 헤더 */}
+  const renderRoleSelection = () => (
+    <div className="space-y-6">
+      <div className="text-center">
+        <div className="w-14 h-14 bg-gradient-to-br from-purple-500 to-pink-500 rounded-full flex items-center justify-center mx-auto mb-3">
+          <Settings className="h-7 w-7 text-white" />
+        </div>
+        <h1 className="text-2xl font-bold text-gray-900 mb-2">
+          Feple Dashboard
+        </h1>
+        <p className="text-base text-gray-600 mb-4">
+          상담사 평가 및 QC 관리 시스템
+        </p>
+        <div className="bg-white rounded-lg p-4 shadow-sm border border-gray-100 max-w-md mx-auto">
+          <h2 className="text-lg font-semibold text-gray-900 mb-1">
+            사용자 유형 선택
+          </h2>
+          <p className="text-sm text-gray-600">
+            먼저, 귀하의 역할에 맞는 유형을 선택해주세요.
+          </p>
+        </div>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div
+          className="bg-white rounded-xl p-5 shadow-lg border-2 cursor-pointer transition-all duration-300 hover:shadow-xl hover:scale-[1.02] border-gray-200 hover:border-blue-300"
+          onClick={() => setRole("consultant")}
+        >
           <div className="text-center">
-            <div className="w-14 h-14 bg-gradient-to-br from-purple-500 to-pink-500 rounded-full flex items-center justify-center mx-auto mb-3">
-              <Settings className="h-7 w-7 text-white" />
+            <div className="w-12 h-12 rounded-full flex items-center justify-center mx-auto mb-3 bg-blue-100">
+              <Users className="h-6 w-6 text-blue-600" />
             </div>
-            <h1 className="text-2xl font-bold text-gray-900 mb-2">
-              Feple Dashboard
-            </h1>
-            <p className="text-base text-gray-600 mb-4">
-              상담사 평가 및 QC 관리 시스템
+            <h3 className="text-lg font-bold text-gray-900 mb-2">상담사</h3>
+            <p className="text-gray-600 text-sm">
+              개인 성과 대시보드에 접근합니다.
             </p>
-            <div className="bg-white rounded-lg p-4 shadow-sm border border-gray-100 max-w-md mx-auto">
-              <h2 className="text-lg font-semibold text-gray-900 mb-1">
-                사용자 유형 선택
-              </h2>
-              <p className="text-sm text-gray-600">
-                귀하의 역할에 맞는 대시보드로 연결해드립니다
-              </p>
-            </div>
           </div>
-
-          {/* 역할 선택 카드 */}
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            {/* 상담사 카드 */}
-            <div
-              className={`bg-white rounded-xl p-5 shadow-lg border-2 cursor-pointer transition-all duration-300 hover:shadow-xl hover:scale-[1.02] ${
-                selectedRole === "consultant"
-                  ? "border-blue-500 bg-blue-50 shadow-blue-200"
-                  : "border-gray-200 hover:border-blue-300"
-              }`}
-              onClick={() => handleRoleSelect("consultant")}
-            >
-              <div className="text-center">
-                <div
-                  className={`w-12 h-12 rounded-full flex items-center justify-center mx-auto mb-3 ${
-                    selectedRole === "consultant"
-                      ? "bg-blue-500"
-                      : "bg-blue-100"
-                  }`}
-                >
-                  <Users
-                    className={`h-6 w-6 ${
-                      selectedRole === "consultant"
-                        ? "text-white"
-                        : "text-blue-600"
-                    }`}
-                  />
-                </div>
-                <h3 className="text-lg font-bold text-gray-900 mb-2">상담사</h3>
-                <p className="text-gray-600 mb-3 text-sm leading-relaxed">
-                  개인 성과 조회, 피드백 확인,
-                  <br />
-                  교육 자료 및 일정 관리
-                </p>
-                <div className="space-y-1 text-xs text-gray-500">
-                  <div className="flex items-center justify-center">
-                    <UserCheck className="h-3 w-3 mr-1" />
-                    <span>개인 대시보드</span>
-                  </div>
-                  <div className="flex items-center justify-center">
-                    <UserCheck className="h-3 w-3 mr-1" />
-                    <span>성과 분석</span>
-                  </div>
-                  <div className="flex items-center justify-center">
-                    <UserCheck className="h-3 w-3 mr-1" />
-                    <span>상담 파일 업로드</span>
-                  </div>
-                </div>
-                {selectedRole === "consultant" && (
-                  <div className="mt-3 p-2 bg-blue-100 rounded-lg">
-                    <p className="text-blue-800 font-medium text-xs">
-                      선택됨 ✓
-                    </p>
-                  </div>
-                )}
-              </div>
-            </div>
-
-            {/* QC팀 카드 */}
-            <div
-              className={`bg-white rounded-xl p-5 shadow-lg border-2 cursor-pointer transition-all duration-300 hover:shadow-xl hover:scale-[1.02] ${
-                selectedRole === "qc"
-                  ? "border-purple-500 bg-purple-50 shadow-purple-200"
-                  : "border-gray-200 hover:border-purple-300"
-              }`}
-              onClick={() => handleRoleSelect("qc")}
-            >
-              <div className="text-center">
-                <div
-                  className={`w-12 h-12 rounded-full flex items-center justify-center mx-auto mb-3 ${
-                    selectedRole === "qc" ? "bg-purple-500" : "bg-purple-100"
-                  }`}
-                >
-                  <Shield
-                    className={`h-6 w-6 ${
-                      selectedRole === "qc" ? "text-white" : "text-purple-600"
-                    }`}
-                  />
-                </div>
-                <h3 className="text-lg font-bold text-gray-900 mb-2">
-                  QC팀 (품질관리)
-                </h3>
-                <p className="text-gray-600 mb-3 text-sm leading-relaxed">
-                  상담사 모니터링, 평가 관리,
-                  <br />팀 성과 분석 및 위험 알림
-                </p>
-                <div className="space-y-1 text-xs text-gray-500">
-                  <div className="flex items-center justify-center">
-                    <UserCheck className="h-3 w-3 mr-1" />
-                    <span>전체 대시보드</span>
-                  </div>
-                  <div className="flex items-center justify-center">
-                    <UserCheck className="h-3 w-3 mr-1" />
-                    <span>평가 관리</span>
-                  </div>
-                  <div className="flex items-center justify-center">
-                    <UserCheck className="h-3 w-3 mr-1" />
-                    <span>위험 모니터링</span>
-                  </div>
-                </div>
-                {selectedRole === "qc" && (
-                  <div className="mt-3 p-2 bg-purple-100 rounded-lg">
-                    <p className="text-purple-800 font-medium text-xs">
-                      선택됨 ✓
-                    </p>
-                  </div>
-                )}
-              </div>
-            </div>
-          </div>
-
-          {/* 계속하기 버튼 */}
+        </div>
+        <div
+          className="bg-white rounded-xl p-5 shadow-lg border-2 cursor-pointer transition-all duration-300 hover:shadow-xl hover:scale-[1.02] border-gray-200 hover:border-purple-300"
+          onClick={() => setRole("qc")}
+        >
           <div className="text-center">
-            <button
-              onClick={handleContinue}
-              disabled={!selectedRole}
-              className={`inline-flex items-center px-6 py-3 rounded-lg text-sm font-semibold transition-all duration-300 ${
-                selectedRole
-                  ? "bg-gradient-to-r from-purple-600 to-pink-600 text-white hover:from-purple-700 hover:to-pink-700 hover:scale-105 shadow-lg hover:shadow-xl"
-                  : "bg-gray-300 text-white cursor-not-allowed"
-              }`}
-            >
-              {selectedRole ? (
-                <>
-                  <span className="!text-white">
-                    {selectedRole === "consultant"
-                      ? "상담사 대시보드로"
-                      : "QC 대시보드로"}
-                  </span>
-                  <ArrowRight className="ml-2 h-4 w-4 !text-white" />
-                </>
-              ) : (
-                <span>먼저 역할을 선택해주세요</span>
-              )}
-            </button>
+            <div className="w-12 h-12 rounded-full flex items-center justify-center mx-auto mb-3 bg-purple-100">
+              <Shield className="h-6 w-6 text-purple-600" />
+            </div>
+            <h3 className="text-lg font-bold text-gray-900 mb-2">
+              QC팀 (품질관리)
+            </h3>
+            <p className="text-gray-600 text-sm">
+              전체 상담사 관리 대시보드에 접근합니다.
+            </p>
           </div>
         </div>
       </div>
+    </div>
+  );
+
+  const renderLoginForm = () => (
+    <div className="w-full max-w-md text-center">
+      <div className="w-14 h-14 bg-gradient-to-br from-purple-500 to-pink-500 rounded-full flex items-center justify-center mx-auto mb-3">
+        {role === "consultant" ? (
+          <Users className="h-7 w-7 text-white" />
+        ) : (
+          <Shield className="h-7 w-7 text-white" />
+        )}
+      </div>
+      <h1 className="text-2xl font-bold text-gray-900 mb-2">
+        {role === "consultant" ? "상담사" : "QC팀"} 로그인
+      </h1>
+      <p className="text-base text-gray-600 mb-6">
+        이메일 주소를 입력하시면, 해당 주소로 로그인 링크를 보내드립니다.
+      </p>
+
+      {submitted ? (
+        <div className="bg-green-50 border-2 border-green-200 rounded-lg p-6 text-center">
+          <Mail className="h-10 w-10 text-green-500 mx-auto mb-3" />
+          <h2 className="text-lg font-semibold text-green-800">
+            이메일을 확인해주세요!
+          </h2>
+          <p className="text-green-700 mt-2">
+            <span className="font-semibold">{email}</span>로 로그인 링크를
+            성공적으로 보냈습니다. <br />
+            메일함 확인 후 링크를 클릭해 로그인을 완료해주세요.
+          </p>
+        </div>
+      ) : (
+        <form
+          onSubmit={handleLogin}
+          className="bg-white rounded-lg p-6 shadow-md border border-gray-200 space-y-4"
+        >
+          <div className="relative">
+            <Mail className="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-gray-400" />
+            <input
+              type="email"
+              placeholder="이메일 주소를 입력하세요"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              className="w-full pl-10 pr-4 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-pink-500 focus:border-pink-500 transition"
+            />
+          </div>
+          <button
+            type="submit"
+            disabled={loading}
+            className={`w-full inline-flex items-center justify-center px-6 py-3 rounded-lg text-sm font-semibold transition-all duration-300 ${
+              loading
+                ? "bg-gray-300 text-white cursor-not-allowed"
+                : "bg-gradient-to-r from-purple-600 to-pink-600 text-white hover:from-purple-700 hover:to-pink-700 hover:scale-105 shadow-lg hover:shadow-xl"
+            }`}
+          >
+            {loading ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                <span>전송 중...</span>
+              </>
+            ) : (
+              <>
+                <span className="text-white">로그인 링크 받기</span>
+                <ArrowRight className="ml-2 h-4 w-4 text-white" />
+              </>
+            )}
+          </button>
+          {error && <p className="text-red-500 text-sm mt-2">{error}</p>}
+        </form>
+      )}
+      <button
+        onClick={() => {
+          setRole(null);
+          setSubmitted(false);
+          setError(null);
+          setEmail("");
+        }}
+        className="mt-6 text-sm text-gray-600 hover:text-pink-600 transition"
+      >
+        &larr; 역할 다시 선택하기
+      </button>
+    </div>
+  );
+
+  return (
+    <div className="bg-gradient-to-br from-pink-50 via-purple-50 to-indigo-50 min-h-screen flex items-center justify-center p-4">
+      {!role ? (
+        <div className="container mx-auto px-4 py-6 max-w-4xl">
+          {renderRoleSelection()}
+        </div>
+      ) : (
+        <div className="w-full max-w-md">{renderLoginForm()}</div>
+      )}
     </div>
   );
 }

--- a/src/app/qc/page.tsx
+++ b/src/app/qc/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import DashboardLayout from "@/components/DashboardLayout";
 import {
   Users,
@@ -16,6 +16,7 @@ import {
   fixedConsultantInfo,
   teamConsultantMapping,
 } from "@/data/fixedQcMockData";
+import { useUser } from "@/context/UserContext";
 
 // 18명 전체 상담사 배열 생성
 const getAllConsultants = () =>
@@ -41,6 +42,7 @@ const teams = Object.entries(teamConsultantMapping).map(([id, ids]) => ({
 }));
 
 export default function QCDashboardPage() {
+  const { setUserInfo } = useUser();
   const [searchTerm, setSearchTerm] = useState("");
   const [showResults, setShowResults] = useState(false);
   const [selectedTeam, setSelectedTeam] = useState<string>("");
@@ -50,8 +52,13 @@ export default function QCDashboardPage() {
   const [teamMemberPage, setTeamMemberPage] = useState(0);
 
   // QC 정보
-  const qcName = "점소이현서";
+  const qcName = "오현서";
   const qcInitial = qcName[0];
+
+  // UserContext에 사용자 정보 설정
+  useEffect(() => {
+    setUserInfo({ name: `${qcName} QC님`, initial: qcInitial });
+  }, [setUserInfo, qcName, qcInitial]);
 
   // 오늘 날짜
   const today = new Date(Date.now());

--- a/src/app/qc/performance/page.tsx
+++ b/src/app/qc/performance/page.tsx
@@ -30,9 +30,16 @@ function QCMonitoringContent() {
     null
   );
   const [hasSearched, setHasSearched] = useState(false); // 조회 여부 상태
+  const [isInitialAutoSearchDone, setIsInitialAutoSearchDone] =
+    useState(false); // 자동 조회 완료 여부 플래그
 
   // URL 파라미터에서 자동 조회 처리
   useEffect(() => {
+    // 자동 조회가 이미 한 번 실행되었다면, 더 이상 URL 파라미터를 확인하지 않음
+    if (isInitialAutoSearchDone) {
+      return;
+    }
+
     const startDateParam = searchParams.get("startDate");
     const endDateParam = searchParams.get("endDate");
     const departmentParam = searchParams.get("department");
@@ -58,6 +65,8 @@ function QCMonitoringContent() {
       // 자동 조회 실행
       setHasSearched(true);
       setSelectedSessionNo(null);
+      // 자동 조회가 완료되었음을 표시
+      setIsInitialAutoSearchDone(true);
 
       console.log(
         "자동 조회 실행:",
@@ -70,7 +79,7 @@ function QCMonitoringContent() {
         consultantParam
       );
     }
-  }, [searchParams, setDateRange]);
+  }, [searchParams, setDateRange, isInitialAutoSearchDone]);
 
   // 부서 데이터
   const departments = [

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -4,11 +4,13 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { LayoutDashboard, Users, BarChart3, Upload } from "lucide-react";
 import { useSidebar } from "../context/SidebarContext";
+import { useUser } from "@/context/UserContext";
 
 export default function Sidebar() {
   const pathname = usePathname();
   const { setIsHovered, setIsMenuClicked, shouldShowContent, sidebarWidth } =
     useSidebar();
+  const { userInfo, isLoading } = useUser();
 
   // 현재 경로가 상담사용 대시보드인지 확인 (정확한 매칭)
   const isConsultantMode =
@@ -113,18 +115,16 @@ export default function Sidebar() {
           }`}
         >
           <div className="sidebar-user-avatar">
-            <span>{isConsultantMode ? "상" : "관"}</span>
+            <span>{isLoading ? "..." : userInfo.initial}</span>
           </div>
           {/* 사용자 정보 텍스트 - 확장 시에만 렌더링 */}
           {shouldShowContent && (
             <div className="transition-all duration-300 opacity-100 translate-x-0 flex-1 ml-2">
               <p className="text-xs font-medium text-gray-900 korean-text whitespace-nowrap">
-                {isConsultantMode ? "상담사" : "관리자"}
+                {isLoading ? "Loading..." : userInfo.name}
               </p>
               <p className="text-xs text-pink-600 korean-text whitespace-nowrap">
-                {isConsultantMode
-                  ? "consultant@company.com"
-                  : "admin@company.com"}
+                {isLoading ? "Loading..." : userInfo.email}
               </p>
             </div>
           )}

--- a/src/context/DateRangeContext.tsx
+++ b/src/context/DateRangeContext.tsx
@@ -15,8 +15,8 @@ const DateRangeContext = createContext<DateRangeContextType | undefined>(
 
 // 어제 날짜 계산 함수 (한국 시간 기준) - 테스트용 고정 날짜
 const getYesterdayDate = () => {
-  // 테스트를 위해 고정된 오늘 날짜 사용 (2025-07-17)
-  const today = new Date("2025-07-17");
+  // 테스트를 위해 고정된 오늘 날짜 사용
+  const today = new Date(Date.now());
 
   const yesterday = new Date(today);
   yesterday.setDate(today.getDate() - 1);

--- a/src/context/UserContext.tsx
+++ b/src/context/UserContext.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  ReactNode,
+  useCallback,
+} from "react";
+import { supabase } from "@/lib/supabaseClient";
+
+interface UserInfo {
+  name: string;
+  initial: string;
+  email: string;
+}
+
+interface UserContextType {
+  userInfo: UserInfo;
+  setUserInfo: (info: Partial<Pick<UserInfo, "name" | "initial">>) => void;
+  isLoading: boolean;
+}
+
+const UserContext = createContext<UserContextType | undefined>(undefined);
+
+export function UserProvider({ children }: { children: ReactNode }) {
+  const [userInfo, setUserInfoState] = useState<UserInfo>({
+    name: "사용자",
+    initial: "사",
+    email: "loading...",
+  });
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchUserEmail = async () => {
+      setIsLoading(true);
+      try {
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
+        if (user && user.email) {
+          setUserInfoState((prev) => ({ ...prev, email: user.email }));
+        } else {
+          setUserInfoState((prev) => ({ ...prev, email: "Not logged in" }));
+        }
+      } catch (error) {
+        console.error("Error fetching user email:", error);
+        setUserInfoState((prev) => ({
+          ...prev,
+          email: "Error fetching email",
+        }));
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchUserEmail();
+
+    const { data: authListener } = supabase.auth.onAuthStateChange(
+      (event, session) => {
+        const user = session?.user;
+        if (user && user.email) {
+          setUserInfoState((prev) => ({ ...prev, email: user.email }));
+        } else {
+          setUserInfoState((prev) => ({ ...prev, email: "Not logged in" }));
+        }
+      }
+    );
+
+    return () => {
+      authListener.subscription.unsubscribe();
+    };
+  }, []);
+
+  const setUserInfo = useCallback(
+    (info: Partial<Pick<UserInfo, "name" | "initial">>) => {
+      setUserInfoState((prev) => ({ ...prev, ...info }));
+    },
+    []
+  );
+
+  return (
+    <UserContext.Provider value={{ userInfo, setUserInfo, isLoading }}>
+      {children}
+    </UserContext.Provider>
+  );
+}
+
+export function useUser() {
+  const context = useContext(UserContext);
+  if (context === undefined) {
+    throw new Error("useUser must be used within a UserProvider");
+  }
+  return context;
+}


### PR DESCRIPTION
## 주요 변경 사항 요약 (Summary of Changes)

   1. ✨ 기능: Supabase 이메일 인증(Magic Link) 도입
       * 기존의 단순 역할 선택 페이지(src/app/page.tsx)를 이메일 기반 로그인 시스템으로 전면 개편했습니다.
       * 사용자는 '상담사' 또는 'QC팀' 역할을 선택한 후, 이메일을 입력하여 로그인 링크를 받을 수 있습니다.
       * 이메일로 전송된 링크를 클릭하면 자동으로 인증 및 로그인이 완료되고, 역할에 맞는 대시보드로 리디렉션됩니다.
       * Vercel 배포 환경을 고려하여 리디렉션 URL을 동적으로 생성하고, 관련 설정 방법을 안내했습니다.

   2. ✨ 기능: 사이드바 사용자 정보 동적 표시
       * 사이드바에 하드코딩되어 있던 사용자 정보(이름, 이니셜, 이메일)를 실제 로그인된 사용자 데이터와 연동했습니다.
       * UserContext를 생성하여 전역적으로 사용자 이메일을 관리합니다.
       * 각 대시보드 페이지(consultant, qc)가 로드될 때, 해당 페이지의 사용자 이름과 이니셜을 UserContext에 설정합니다.
       * 사이드바는 이 UserContext의 정보를 구독하여 항상 최신 사용자 정보를 표시합니다.

   3. 🐛 버그 수정: 무한 렌더링(Maximum update depth exceeded) 오류 해결
       * UserContext의 상태 업데이트 로직으로 인해 발생하던 무한 리렌더링 문제를 해결했습니다.
       * UserContext 내의 상태 설정 함수를 useCallback으로 감싸 불필요한 함수 재생성을 방지했습니다.
       * 각 페이지의 useEffect 의존성 배열을 최적화하여 무한 루프의 원인을 근본적으로 제거했습니다.

   4. 💄 UI 개선: 로그인 폼 중앙 정렬
       * 로그인 페이지에서 이메일 입력 폼이 화면 중앙에 완벽하게 위치하도록 레이아웃을 수정했습니다.