### PR TITLE
feat: 로그인 페이지에 이름 입력 필드 추가 및 사용자 정보 업데이트 로직 개선

### DIFF
--- a/src/app/consultant/page.tsx
+++ b/src/app/consultant/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import DashboardLayout from "@/components/DashboardLayout";
 import { RadarChart } from "@/components/charts/RadarChart";
@@ -11,16 +11,7 @@ import { useUser } from "@/context/UserContext";
 export default function ConsultantDashboardPage() {
   const router = useRouter();
   const { setDateRange } = useDateRange();
-  const { setUserInfo } = useUser();
-
-  // 상담사 정보 (이름, 이니셜)
-  const userName = "마교준석";
-  const userInitial = userName[0];
-
-  // UserContext에 사용자 정보 설정
-  useEffect(() => {
-    setUserInfo({ name: `${userName} 상담사`, initial: userInitial });
-  }, [setUserInfo, userName, userInitial]);
+  const { userInfo } = useUser(); // useUser 훅에서 userInfo 직접 가져오기
 
   // 기간 선택 상태
   const [selectedPeriod, setSelectedPeriod] = useState<
@@ -216,11 +207,11 @@ export default function ConsultantDashboardPage() {
             {/* 인사말 카드 */}
             <div className="bg-gradient-to-r from-pink-400 to-purple-400 rounded-xl p-4 shadow-lg flex items-center gap-3 animate-pulse-glow">
               <div className="h-10 w-10 rounded-full bg-white/30 flex items-center justify-center text-lg font-bold text-white shadow">
-                {userInitial}
+                {userInfo.initial}
               </div>
               <div>
                 <div className="text-base font-bold text-white flex items-center gap-2">
-                  {userName} 상담사님 <span className="animate-bounce">👋🏻</span>
+                  {userInfo.name} 상담사님 <span className="animate-bounce">👋🏻</span>
                 </div>
                 <div className="text-xs text-pink-100 mt-1">
                   오늘도 힘내세요! Feple이 함께합니다 :)
@@ -322,3 +313,4 @@ export default function ConsultantDashboardPage() {
     </DashboardLayout>
   );
 }
+

--- a/src/app/qc/page.tsx
+++ b/src/app/qc/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import DashboardLayout from "@/components/DashboardLayout";
 import {
   Users,
@@ -42,7 +42,7 @@ const teams = Object.entries(teamConsultantMapping).map(([id, ids]) => ({
 }));
 
 export default function QCDashboardPage() {
-  const { setUserInfo } = useUser();
+  const { userInfo } = useUser(); // useUser 훅에서 userInfo 직접 가져오기
   const [searchTerm, setSearchTerm] = useState("");
   const [showResults, setShowResults] = useState(false);
   const [selectedTeam, setSelectedTeam] = useState<string>("");
@@ -50,15 +50,6 @@ export default function QCDashboardPage() {
   const [riskAlertPage, setRiskAlertPage] = useState(0);
   const [inspectionPage, setInspectionPage] = useState(0);
   const [teamMemberPage, setTeamMemberPage] = useState(0);
-
-  // QC 정보
-  const qcName = "오현서";
-  const qcInitial = qcName[0];
-
-  // UserContext에 사용자 정보 설정
-  useEffect(() => {
-    setUserInfo({ name: `${qcName} QC님`, initial: qcInitial });
-  }, [setUserInfo, qcName, qcInitial]);
 
   // 오늘 날짜
   const today = new Date(Date.now());
@@ -312,11 +303,11 @@ export default function QCDashboardPage() {
           {/* 인사말 카드 */}
           <div className="bg-gradient-to-r from-pink-400 to-purple-400 rounded-xl p-4 shadow-lg flex items-center gap-3 animate-pulse-glow">
             <div className="h-10 w-10 rounded-full bg-white/30 flex items-center justify-center text-lg font-bold text-white shadow">
-              {qcInitial}
+              {userInfo.initial}
             </div>
             <div>
               <div className="text-base font-bold text-white flex items-center gap-2">
-                {qcName} QC님 <span className="animate-bounce">👋🏻</span>
+                {userInfo.name} QC님 <span className="animate-bounce">👋🏻</span>
               </div>
               <div className="text-xs text-pink-100 mt-1">
                 오늘도 힘내세요! Feple이 함께합니다 :)


### PR DESCRIPTION
## 주요 변경 사항 (Key Changes)

  1. 로그인 기능 강화
      - 이름 입력 필드 추가: 로그인 페이지(src/app/page.tsx)에 이메일과 더불어 '이름'을 입력받는 UI를 추가했습니다.
      - `user_metadata` 저장: 로그인 요청 시, signInWithOtp 함수의 options.data를 통해 사용자의 이름과 역할을 Supabase
        user_metadata에 저장합니다. (신규 가입 시 적용)

  2. 사용자 정보 업데이트 로직 구현 (핵심)
      - 문제 해결: 기존 사용자가 다른 이름으로 로그인 시 user_metadata가 갱신되지 않는 문제를 해결했습니다.
      - `localStorage` 활용: 로그인 시 입력된 이름을 브라우저의 localStorage에 임시 저장합니다.
      - `updateUser` API 적용: UserContext에서 로그인 세션을 감지했을 때, localStorage의 이름과 user_metadata의 이름이 다를 경우
        supabase.auth.updateUser를 호출하여 정보를 명시적으로 동기화합니다.

  3. `UserContext` 리팩토링 및 중앙화
      - 데이터 소스 단일화: 이제 UserContext가 user_metadata로부터 이름, 이메일, 역할을 직접 가져옵니다.
      - 동적 이니셜 생성: 가져온 이름의 첫 글자를 이용해 사용자의 이니셜을 동적으로 생성합니다.
      - `setUserInfo` 제거: 각 페이지에서 수동으로 사용자 정보를 주입하던 setUserInfo 함수와 관련 로직을 제거하여, 이전에
        발생했던 무한 렌더링 오류의 근본 원인을 제거했습니다.

  4. 코드 정리 및 버그 수정
      - `useEffect` 제거: consultant/page.tsx와 qc/page.tsx에서 더 이상 필요 없어진 useEffect 로직을 삭제하여 코드를
        간소화했습니다.
      - ESLint/TypeScript 오류 해결: UserContext에서 사용되지 않는 콜백 파라미터(event, session)를 제거하여 Vercel 배포 시
        발생하던 빌드 오류를 해결했습니다.

  테스트 방법 (How to Test)

   1. 로그아웃 상태에서 로그인 페이지로 이동합니다.
   2. Case 1 (신규 사용자): 새로운 이름과 이메일로 로그인 링크를 전송받아 접속합니다.
       - 사이드바와 대시보드에 입력한 이름과 이니셜이 올바르게 표시되는지 확인합니다.
   3. 로그아웃합니다.
   4. Case 2 (기존 사용자, 이름 변경): 동일한 이메일과 다른 이름으로 로그인 링크를 전송받아 접속합니다.
       - 사이드바와 대시보드에 새롭게 입력한 이름으로 정보가 업데이트되었는지 확인합니다.
   5. Supabase 대시보드의 Authentication > Users 탭에서 해당 유저의 user_metadata가 올바르게 저장/갱신되었는지 확인합니다.