### PR TITLE
feat: 사이드바에 로그아웃 버튼 추가 및 사용자 정보 로딩 개선

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2,7 +2,13 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { LayoutDashboard, Users, BarChart3, Upload } from "lucide-react";
+import {
+  LayoutDashboard,
+  Users,
+  BarChart3,
+  Upload,
+  LogOut, // 로그아웃 아이콘 추가
+} from "lucide-react";
 import { useSidebar } from "../context/SidebarContext";
 import { useUser } from "@/context/UserContext";
 
@@ -10,7 +16,7 @@ export default function Sidebar() {
   const pathname = usePathname();
   const { setIsHovered, setIsMenuClicked, shouldShowContent, sidebarWidth } =
     useSidebar();
-  const { userInfo, isLoading } = useUser();
+  const { userInfo, isLoading, logout } = useUser(); // logout 함수 가져오기
 
   // 현재 경로가 상담사용 대시보드인지 확인 (정확한 매칭)
   const isConsultantMode =
@@ -115,18 +121,44 @@ export default function Sidebar() {
           }`}
         >
           <div className="sidebar-user-avatar">
-            <span>{isLoading ? "..." : userInfo.initial}</span>
+            {isLoading ? (
+              <div className="w-full h-full bg-gray-200 animate-pulse rounded-full"></div>
+            ) : (
+              <span>{userInfo.initial}</span>
+            )}
           </div>
           {/* 사용자 정보 텍스트 - 확장 시에만 렌더링 */}
-          {shouldShowContent && (
-            <div className="transition-all duration-300 opacity-100 translate-x-0 flex-1 ml-2">
-              <p className="text-xs font-medium text-gray-900 korean-text whitespace-nowrap">
-                {isLoading ? "Loading..." : userInfo.name}
-              </p>
-              <p className="text-xs text-pink-600 korean-text whitespace-nowrap">
-                {isLoading ? "Loading..." : userInfo.email}
-              </p>
-            </div>
+          {shouldShowContent &&
+            (isLoading ? (
+              <div className="flex-1 ml-2 space-y-1.5">
+                <div className="h-3 w-24 bg-gray-200 animate-pulse rounded"></div>
+                <div className="h-3 w-32 bg-gray-200 animate-pulse rounded"></div>
+              </div>
+            ) : (
+              <div className="transition-all duration-300 opacity-100 translate-x-0 flex-1 ml-2 overflow-hidden">
+                <p
+                  className="text-xs font-medium text-gray-900 korean-text whitespace-nowrap truncate"
+                  title={userInfo.name}
+                >
+                  {userInfo.name}
+                </p>
+                <p
+                  className="text-xs text-pink-600 korean-text whitespace-nowrap truncate"
+                  title={userInfo.email}
+                >
+                  {userInfo.email}
+                </p>
+              </div>
+            ))}
+          {/* 로그아웃 버튼 - 확장 시에만 렌더링 */}
+          {shouldShowContent && !isLoading && (
+            <button
+              onClick={logout}
+              className="ml-2 p-1.5 rounded-full text-gray-500 hover:bg-red-100 hover:text-red-600 transition-colors"
+              title="로그아웃"
+            >
+              <LogOut className="h-4 w-4" />
+            </button>
           )}
         </div>
       </div>

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,22 +1,22 @@
-import { createClient } from '@supabase/supabase-js'
+import { createClient } from "@supabase/supabase-js";
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
-console.log('🔧 Supabase 환경변수 확인:', {
-  url: supabaseUrl ? '✅ 설정됨' : '❌ 없음',
-  key: supabaseAnonKey ? '✅ 설정됨' : '❌ 없음'
+console.log("🔧 Supabase 환경변수 확인:", {
+  url: supabaseUrl ? "✅ 설정됨" : "❌ 없음",
+  key: supabaseAnonKey ? "✅ 설정됨" : "❌ 없음",
 });
 
 if (!supabaseUrl) {
-  throw new Error("Missing env.NEXT_PUBLIC_SUPABASE_URL")
+  throw new Error("Missing env.NEXT_PUBLIC_SUPABASE_URL");
 }
 if (!supabaseAnonKey) {
-  throw new Error("Missing env.NEXT_PUBLIC_SUPABASE_ANON_KEY")
+  throw new Error("Missing env.NEXT_PUBLIC_SUPABASE_ANON_KEY");
 }
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
   auth: {
-    persistSession: false
-  }
-})
+    persistSession: true,
+  },
+});


### PR DESCRIPTION
## 주요 변경 사항 (Key Changes)

  1. 동적 사용자 인증 시스템 구현
      - 로그인 시 이름 입력: 로그인 페이지에 '이름' 입력 필드를 추가하여, 이메일과 함께 사용자 이름을 수집합니다.
      - `user_metadata` 활용: 수집된 이름과 역할 정보는 Supabase user_metadata에 저장됩니다.
      - 이름 업데이트 로직: 기존 사용자가 다른 이름으로 로그인할 경우, SIGNED_IN 이벤트를 감지하여 user_metadata를 최신 이름으로 안전하게
         업데이트합니다.

  2. 새로고침 시 정보 초기화 버그 해결 (핵심)
      - 문제 원인: 새로고침 시 Supabase 클라이언트의 세션 복원 작업과 앱의 데이터 요청 간의 실행 순서가 꼬이는 레이스 컨디션(Race
        Condition)이 원인이었습니다.
      - 해결: UserContext의 로직을 onAuthStateChange 리스너 중심으로 완전히 재구성했습니다. 이 리스너는 새로고침(INITIAL_SESSION),
        로그인(SIGNED_IN), 로그아웃(SIGNED_OUT) 등 모든 인증 이벤트를 안정적으로 처리하여, 더 이상 정보가 초기화되지 않습니다.

  3. 로그아웃 기능 추가
      - 사이드바 사용자 정보 영역에 LogOut 아이콘 버튼을 추가하여, 사용자가 명시적으로 로그아웃하고 로그인 페이지로 돌아갈 수 있는 기능을
         구현했습니다.

  4. UI/UX 개선
      - 스켈레톤 UI 적용: 새로고침 또는 페이지 이동 시, 사용자 정보를 불러오는 동안 "사용자"라는 기본값이 깜빡이는 대신, 부드러운
        스켈레톤 UI가 표시되도록 하여 사용자 경험을 개선했습니다.

  5. 코드 리팩토링 및 안정화
      - 실패한 로직 제거: 문제를 해결하지 못했던 AuthUpdater 컴포넌트와 관련 로직을 프로젝트에서 완전히 삭제했습니다.
      - `UserContext` 단순화: UserContext의 역할을 인증 상태를 화면에 반영하는 순수한 역할로 단순화하여 코드의 복잡도를 낮추고 예측
        가능성을 높였습니다.

  테스트 방법 (How to Test)

   1. 로그아웃 상태에서 로그인 페이지로 이동합니다.
   2. Case 1 (신규 사용자):
       - 새로운 이름("홍길동")과 이메일로 로그인합니다.
       - 대시보드 진입 후, 사이드바와 인사말 카드에 "홍길동" 이름이 올바르게 표시되는지 확인합니다.
   3. 새로고침:
       - 브라우저를 새로고침(F5 또는 Ctrl+R)합니다.
       - 잠시 스켈레톤 UI가 보인 후, "홍길동" 정보가 그대로 유지되는지 반드시 확인합니다.
   4. 로그아웃을 클릭하여 로그인 페이지로 돌아갑니다.
   5. Case 2 (기존 사용자, 이름 변경):
       - 동일한 이메일과 다른 이름("전우치")으로 다시 로그인합니다.
       - 대시보드 진입 후, 사이드바와 인사말 카드에 "전우치"로 이름이 업데이트되었는지 확인합니다.
   6. 다시 새로고침하여, "전우치" 정보가 초기화되지 않고 잘 유지되는지 확인합니다.